### PR TITLE
shared cache

### DIFF
--- a/apps/core0/helper/filesystem/filesystem.go
+++ b/apps/core0/helper/filesystem/filesystem.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	CacheBaseDir    = "/var/cache"
+	CacheZeroFSDir  = CacheBaseDir + "/zerofs"
 	LocalRouterFile = CacheBaseDir + "/router.yaml"
 )
 
@@ -176,7 +177,7 @@ func MountFList(namespace, storage, src string, target string, hooks ...pm.Runne
 	os.RemoveAll(backend)
 	os.MkdirAll(backend, 0755)
 
-	cache := settings.Settings.Globals.Get("cache", path.Join(CacheBaseDir, "zerofs"))
+	cache := settings.Settings.Globals.Get("cache", CacheZeroFSDir)
 	g8ufs := []string{
 		"-reset",
 		"-backend", backend,

--- a/apps/core0/subsys/kvm/manager.go
+++ b/apps/core0/subsys/kvm/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libvirt/libvirt-go"
 	"github.com/op/go-logging"
 	"github.com/pborman/uuid"
+	"github.com/threefoldtech/0-core/apps/core0/helper/filesystem"
 	"github.com/threefoldtech/0-core/apps/core0/helper/socat"
 	"github.com/threefoldtech/0-core/apps/core0/screen"
 	"github.com/threefoldtech/0-core/apps/core0/subsys/containers"
@@ -204,15 +205,17 @@ type Mount struct {
 
 type CreateParams struct {
 	NicParams
-	Name    string            `json:"name"`
-	CPU     int               `json:"cpu"`
-	Memory  int               `json:"memory"`
-	FList   string            `json:"flist"`
-	Mount   []Mount           `json:"mount"`
-	Media   []Media           `json:"media"`
-	Config  map[string]string `json:"config"` //overrides vm config (from flist)
-	Tags    pm.Tags           `json:"tags"`
-	Storage string            `json:"storage"` //ardb storage needed for g8ufs mounts.
+	Name       string            `json:"name"`
+	CPU        int               `json:"cpu"`
+	Memory     int               `json:"memory"`
+	FList      string            `json:"flist"`
+	ShareCache bool              `json:"share_cache"`
+	Cmdline    string            `json:"cmdline"` //only used with flist
+	Mount      []Mount           `json:"mount"`
+	Media      []Media           `json:"media"`
+	Config     map[string]string `json:"config"` //overrides vm config (from flist)
+	Tags       pm.Tags           `json:"tags"`
+	Storage    string            `json:"storage"` //ardb storage needed for g8ufs mounts.
 }
 
 type FListBootConfig struct {
@@ -246,8 +249,8 @@ func (c *CreateParams) Valid() error {
 	}
 
 	for _, mnt := range c.Mount {
-		if mnt.Target == "root" {
-			return fmt.Errorf("mount target 'root' is reserved")
+		if mnt.Target == "root" || mnt.Target == "zoscache" {
+			return fmt.Errorf("mount target '%s' is reserved", mnt.Target)
 		}
 	}
 
@@ -892,6 +895,41 @@ func (m *kvmManager) updateView() {
 	screen.Refresh()
 }
 
+func (m *kvmManager) prepareFlist(params *CreateParams, domain *Domain) error {
+	config, err := m.flistMount(domain.UUID, params.FList, params.Storage, params.Config)
+	if err != nil {
+		return err
+	}
+
+	var cmdline string
+	if !config.NoDefault {
+		cmdline = "rootfstype=9p rootflags=rw,trans=virtio,cache=loose root=root"
+	}
+
+	cmdline = strings.Join([]string{cmdline, config.Cmdline, params.Cmdline}, " ")
+
+	domain.OS.Kernel = path.Join(config.Root, utils.SafeNormalize(config.Kernel))
+	if len(config.InitRD) != 0 {
+		domain.OS.InitRD = path.Join(config.Root, utils.SafeNormalize(config.InitRD))
+	}
+
+	domain.OS.Cmdline = strings.TrimSpace(cmdline)
+
+	domain.Devices.Filesystems = append(domain.Devices.Filesystems, Filesystem{
+		Source: FilesystemDir{config.Root},
+		Target: FilesystemDir{"root"}, //the <root> here matches the one in the cmdline root=<root>
+	})
+
+	if params.ShareCache {
+		domain.Devices.Filesystems = append(domain.Devices.Filesystems, Filesystem{
+			Source: FilesystemDir{filesystem.CacheZeroFSDir},
+			Target: FilesystemDir{"zoscache"}, //the <root> here matches the one in the cmdline root=<root>
+		})
+	}
+
+	return nil
+}
+
 func (m *kvmManager) create(cmd *pm.Command) (uuid interface{}, err error) {
 	defer m.updateView()
 	var params CreateParams
@@ -913,33 +951,9 @@ func (m *kvmManager) create(cmd *pm.Command) (uuid interface{}, err error) {
 	}
 
 	if len(params.FList) != 0 {
-		var config FListBootConfig
-		config, err = m.flistMount(domain.UUID, params.FList, params.Storage, params.Config)
-		if err != nil {
+		if err := m.prepareFlist(&params, domain); err != nil {
 			return nil, err
 		}
-		var cmdline string
-		if !config.NoDefault {
-			cmdline = "rootfstype=9p rootflags=rw,trans=virtio,cache=loose root=root"
-		}
-
-		if len(config.Cmdline) != 0 {
-			cmdline = fmt.Sprintf("%s %s", cmdline, config.Cmdline)
-		}
-
-		domain.OS.Kernel = path.Join(config.Root, utils.SafeNormalize(config.Kernel))
-		if len(config.InitRD) != 0 {
-			domain.OS.InitRD = path.Join(config.Root, utils.SafeNormalize(config.InitRD))
-		}
-
-		domain.OS.Cmdline = strings.TrimSpace(cmdline)
-
-		fs := Filesystem{
-			Source: FilesystemDir{config.Root},
-			Target: FilesystemDir{"root"}, //the <root> here matches the one in the cmdline root=<root>
-		}
-
-		domain.Devices.Filesystems = append(domain.Devices.Filesystems, fs)
 	}
 
 	m.domainsInfoRWMutex.Lock()

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -2149,6 +2149,8 @@ class KvmManager:
         'name': str,
         'media': typchk.Or([_media_dict], typchk.IsNone()),
         'flist': typchk.Or(str, typchk.IsNone()),
+        'cmdline': typchk.Or(str, typchk.IsNone()),
+        'share_cache': bool,
         'cpu': int,
         'memory': int,
         'nics': [{
@@ -2227,7 +2229,8 @@ class KvmManager:
         self._client = client
 
     def create(self, name, media=None, flist=None, cpu=2, memory=512,
-               nics=None, port=None, mount=None, tags=None, config=None, storage=None):
+               nics=None, port=None, mount=None, tags=None, config=None, storage=None,
+               cmdline=None, share_cache=False):
         """
         :param name: Name of the kvm domain
         :param media: (optional) array of media objects to attach to the machine, where the first object is the boot device
@@ -2262,6 +2265,10 @@ class KvmManager:
         :param storage: A Url to the ardb storage to use to mount the root flist
                         if not provided, the default one from core0 configuration will be used. Only applicable
                         when booting a machine from an flist.
+        :param cmdline: When booting from an flist, add extra kernel cmdline arguments
+        :param share_cache: if set to true, the /var/cache/zerofs directory will be shared to guest machine
+                        as 'zoscache' in rw mode. It's equavilint to adding {'source': '/var/cache/zerofs', 'target': 'zoscahe', readonly: False}
+                        to the `mount` option.
 
         :note: At least one media or an flist must be provided.
         :return: uuid of the virtual machine
@@ -2275,6 +2282,7 @@ class KvmManager:
             'media': media,
             'cpu': cpu,
             'flist': flist,
+            'cmdline': cmdline,
             'memory': memory,
             'nics': nics,
             'port': port,
@@ -2282,6 +2290,7 @@ class KvmManager:
             'tags': tags,
             'config': config,
             'storage': storage,
+            'share_cache': share_cache,
         }
 
         self._create_chk.check(args)

--- a/tools/ensurecache.sh
+++ b/tools/ensurecache.sh
@@ -36,7 +36,7 @@ function preparedisk {
 
     if [ "$DISK" == "" ]; then
         error "no free disks found"
-        exit 1
+        return 1
     fi
 
     parted -s ${DISK} mktable gpt
@@ -106,11 +106,15 @@ function main {
         # no parition found with that label
         # prepare the first availabel disk
 	    log "${LABEL} not mounted, search for available disk"
-        preparedisk
-        labelmount ${LABEL} ${MNT}
+        if preparedisk; then
+            labelmount ${LABEL} ${MNT}
+        fi
     fi
 
-    hook $MNT
+    if mountpoint -q ${MNT}; then
+        hook ${MNT}
+    fi
+
     sharedcache
 }
 

--- a/tools/ensurecache.sh
+++ b/tools/ensurecache.sh
@@ -90,7 +90,12 @@ function hook {
 
 function sharedcache {
     # try to mount the shared cache if possible
-    if ! mount -t 9p zoscache /var/cache/zerofs; then
+    CACHEPATH=/var/cache/zerofs
+    if [ ! -d ${CACHEPATH} ]; then
+        mkdir -p ${CACHEPATH}
+    fi
+
+    if ! mount -t 9p zoscache ${CACHEPATH}; then
         log "No shared cache exposed to the node"
     fi
 }

--- a/tools/ensurecache.sh
+++ b/tools/ensurecache.sh
@@ -88,6 +88,13 @@ function hook {
     return 0
 }
 
+function sharedcache {
+    # try to mount the shared cache if possible
+    if ! mount -t 9p zoscache /var/cache/zerofs; then
+        log "No shared cache exposed to the node"
+    fi
+}
+
 function main {
     mkdir -p ${MNT}
     if mountpoint -q ${MNT}; then
@@ -104,6 +111,7 @@ function main {
     fi
 
     hook $MNT
+    sharedcache
 }
 
 main


### PR DESCRIPTION
- Add `shared_cache` flag to kvm create which exposes the host zos cache directory to guest machine over plan9
- Add `cmdline` flag to kvm create to pass extra cmdline options to kernels of vms created from flist
- Modify the disk setup process to mount the shared zoscache if available.