### PR TITLE
Add test case for port information and replace g8os with zos

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,7 @@
     ```
     bash trigger_travis.sh master l17-fmjUgycEAcQWWCA
     ```
-### Python G8os Tests
+### Python zos Tests
 - Here is the link for the tests: [testsuite](https://github.com/zero-os/0-core/tree/cron-jobs/tests/testsuite)
-- When travis triggers the python environment, Basically it starts to create packet machine using latest g8os image, then run the tests on it.
+- When travis triggers the python environment, Basically it starts to create packet machine using latest zos image, then run the tests on it.
 - After the tests are done, the packet machine is deleted.

--- a/tests/packet_script.py
+++ b/tests/packet_script.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     manager = packet.Manager(auth_token=token)
     print(os.system('echo $TRAVIS_EVENT_TYPE'))
     if action == 'delete':
-        print('deleting the g8os machine ..')
+        print('deleting the zos machine ..')
         delete_device(manager)
     else:
         branch = sys.argv[3]
@@ -118,7 +118,7 @@ if __name__ == '__main__':
         t = check_status(True, branch)
         if t != 'No_build_triggered':
             print('build has been started at {}'.format(t))
-            print('waiting for g8os build to pass ..')
+            print('waiting for zos build to pass ..')
             check_status(False, branch)
             time.sleep(2)
             url2 = 'https://build.gig.tech/build/history'

--- a/tests/testsuite/a_basic/tests_01_system.py
+++ b/tests/testsuite/a_basic/tests_01_system.py
@@ -11,7 +11,7 @@ class SystemTests(BaseTest):
 
     def setUp(self):
         super(SystemTests, self).setUp()
-        self.check_g8os_connection(SystemTests)
+        self.check_zos_connection(SystemTests)
 
     def get_permission(self, client, path):
         return int(self.stdout(client.bash('stat -c %a {}'.format(path))))
@@ -102,24 +102,58 @@ class SystemTests(BaseTest):
 
         return memInfo
 
-    def getDmibiosInfo(self, client):
+    def get_dmi_bios_info(self, client):
 
         lines = client.bash('dmidecode -t bios').get().stdout.splitlines()
-        mapping = {'Vendor':'vendor', 'Version':'version','Release Date':'release date','Address':'address', 
+        dmi_info = {'Vendor':'vendor', 'Version':'version','Release Date':'release date','Address':'address', 
                     'Runtime Size':'runtime size', 'ROM Size':'rom size','BIOS Revision':'bios revision' }
 
         for line in lines:
             line = line.replace('\t', '')
-            for key in mapping.keys():
+            for key in dmi_info.keys():
                 if key == line[:line.find(':')]:
                     item = (line[line.index(':') + 2 :])
-                    mapping[key] = item
+                    dmi_info[key] = item
         
-        return mapping
+        return dmi_info
+
+    def get_port_info(self, client, protocol):
+        
+        if protocol == 'tcp':
+            lines_1 = client.bash('netstat -tlpn | tail -n+3 | awk "{print \$4}"').get().stdout.splitlines() #ip:port
+            lines_2 = client.bash('netstat -tlpn | tail -n+3 | awk "{print \$7}"').get().stdout.splitlines() #pid
+
+        elif protocol == 'udp':
+            lines_1 = client.bash('netstat -ulpn | tail -n+3 | awk "{print \$4}"').get().stdout.splitlines() #ip:port
+            lines_2 = client.bash('netstat -ulpn | tail -n+3 | awk "{print \$6}"').get().stdout.splitlines() #pid
+
+        else:
+            return 0
+
+        ip = []
+        port = []
+        pid = []
+        # Separate ip, port from ip:port line 
+        for line in lines_1:
+            line = line.replace('\t', '')
+            ip.append(line[: line.rfind(':')])
+            port.append(line[line.rfind(':') + 1 :])
+
+        # Get pid 
+        for line in lines_2:
+            line = line.replace('\t', '')
+            if line[: line.rfind('/')] == '':
+                pid.append('0')
+            else:
+                pid.append(line[: line.rfind('/')])
+
+        port_info = {'ip' : ip, 'port': port, 'pid': pid}
+        return port_info
+
 
     def test001_execute_commands(self):
 
-        """ g8os-001
+        """ zos-001
         *Test case for testing basic commands using  bash and system*
 
         **Test Scenario:**
@@ -161,7 +195,7 @@ class SystemTests(BaseTest):
 
     def test002_kill_list_processes(self):
 
-        """ g8os-002
+        """ zos-002
         *Test case for testing killing and listing processes*
 
         **Test Scenario:**
@@ -193,13 +227,13 @@ class SystemTests(BaseTest):
     @parameterized.expand(['client', 'container'])
     def test003_os_info(self, client_type):
 
-        """ g8os-003
+        """ zos-003
         *Test case for checking on the system os information*
 
         **Test Scenario:**
-        #. Get the os information using g8os/container client
-        #. Get the hostname and compare it with the g8os/container os insformation
-        #. Get the kernal's name and compare it with the g8os/container os insformation
+        #. Get the os information using zos/container client
+        #. Get the hostname and compare it with the zos/container os insformation
+        #. Get the kernal's name and compare it with the zos/container os insformation
         """
 
         self.lg('{} STARTED'.format(self._testID))
@@ -210,14 +244,14 @@ class SystemTests(BaseTest):
             self.container_create()
             client = self.client_container
 
-        self.lg('Get the os information using g8os/container client')
+        self.lg('Get the os information using zos/container client')
         os_info = client.info.os()
 
-        self.lg('Get the hostname and compare it with the g8os/container os insformation')
+        self.lg('Get the hostname and compare it with the zos/container os insformation')
         hostname = client.system('uname -n').get().stdout.strip()
         self.assertEqual(os_info['hostname'], hostname)
 
-        self.lg('Get the kernal\'s name and compare it with the g8os/container os insformation')
+        self.lg('Get the kernal\'s name and compare it with the zos/container os insformation')
         krn_name = client.system('uname -s').get().stdout.strip()
         self.assertEqual(os_info['os'], krn_name.lower())
 
@@ -226,13 +260,13 @@ class SystemTests(BaseTest):
     @parameterized.expand(['client', 'container'])
     def test004_mem_info(self, client_type):
 
-        """ g8os-004
+        """ zos-004
         *Test case for checking on the system memory information*
 
         **Test Scenario:**
-        #. Get the memory information using g8os/container client
+        #. Get the memory information using zos/container client
         #. Get the memory information using bash
-        #. Compare memory g8os/container  results to that of the bash results, should be the same
+        #. Compare memory zos/container  results to that of the bash results, should be the same
         """
         self.lg('{} STARTED'.format(self._testID))
 
@@ -245,30 +279,30 @@ class SystemTests(BaseTest):
         self.lg('get memory info using bash')
         expected_mem_info = self.getMemInfo(client)
 
-        self.lg('get memory info using g8os/container ')
-        g8os_mem_info = client.info.mem()
+        self.lg('get memory info using zos/container ')
+        zos_mem_info = client.info.mem()
 
-        self.lg('compare g8os/container  results to bash results')
-        self.assertEqual(expected_mem_info['total'], g8os_mem_info['total'])
+        self.lg('compare zos/container  results to bash results')
+        self.assertEqual(expected_mem_info['total'], zos_mem_info['total'])
         params_to_check = ['active', 'available', 'buffers', 'cached', 'free', 'inactive']
         for key in params_to_check:
             threshold = 1024 * 10000  # acceptable threshold (10 MB)
-            g8os_value = g8os_mem_info[key]
+            zos_value = zos_mem_info[key]
             expected_value = expected_mem_info[key]
-            self.assertTrue(expected_value - threshold <= g8os_value <= expected_value + threshold, key)
+            self.assertTrue(expected_value - threshold <= zos_value <= expected_value + threshold, key)
 
         self.lg('{} ENDED'.format(self._testID))
 
     @parameterized.expand(['client', 'container'])
     def test005_cpu_info(self, client_type):
 
-        """ g8os-005
+        """ zos-005
         *Test case for checking on the system CPU information*
 
         **Test Scenario:**
-        #. Get the CPU information using g8os/container client
+        #. Get the CPU information using zos/container client
         #. Get the CPU information using bash
-        #. Compare CPU g8os/container  results to that of the bash results, should be the same
+        #. Compare CPU zos/container  results to that of the bash results, should be the same
         """
         self.lg('{} STARTED'.format(self._testID))
 
@@ -281,28 +315,28 @@ class SystemTests(BaseTest):
         self.lg('get cpu info using bash')
         expected_cpu_info = self.getCpuInfo(client)
 
-        self.lg('get cpu info using g8os')
-        g8os_cpu_info = client.info.cpu()
+        self.lg('get cpu info using zos')
+        zos_cpu_info = client.info.cpu()
 
-        self.lg('compare g8os/container results to bash results')
+        self.lg('compare zos/container results to bash results')
         for key in expected_cpu_info.keys():
             if key == 'cores':
                 continue
-            g8os_param_list = [x[key] for x in g8os_cpu_info]
-            self.assertEqual(expected_cpu_info[key], g8os_param_list)
+            zos_param_list = [x[key] for x in zos_cpu_info]
+            self.assertEqual(expected_cpu_info[key], zos_param_list)
 
         self.lg('{} ENDED'.format(self._testID))
 
     @parameterized.expand(['client', 'container'])
     def test006_disk_info(self, client_type):
 
-        """ g8os-006
+        """ zos-006
         *Test case for checking on the disks information*
 
         **Test Scenario:**
-        #. Get the disks information using g8os client
+        #. Get the disks information using zos client
         #. Get the disks information using bas
-        #. Compare disks g8os results to that of the bash results, should be the same
+        #. Compare disks zos results to that of the bash results, should be the same
         """
         self.lg('{} STARTED'.format(self._testID))
 
@@ -315,44 +349,44 @@ class SystemTests(BaseTest):
         self.lg('get disks info using linux bash command (mount)')
         expected_disk_info = self.getDiskInfo(client)
 
-        self.lg('get cpu info using g8os')
-        g8os_disk_info = client.info.disk()
+        self.lg('get cpu info using zos')
+        zos_disk_info = client.info.disk()
 
-        self.lg('compare g8os results to bash results')
-        for disk in g8os_disk_info:
+        self.lg('compare zos results to bash results')
+        for disk in zos_disk_info:
             self.assertIn(disk, expected_disk_info)
 
         self.lg('{} ENDED'.format(self._testID))
 
     def test007_nic_info(self):
 
-        """ g8os-007
+        """ zos-007
         *Test case for checking on the system nic information*
 
         **Test Scenario:**
-        #. Get the nic information using g8os client
+        #. Get the nic information using zos client
         #. Get the information using bash
-        #. Compare nic g8os results to that of the bash results, should be the same
+        #. Compare nic zos results to that of the bash results, should be the same
         """
         self.lg('{} STARTED'.format(self._testID))
 
         self.lg('get nic info using linux bash command (ip a)')
         expected_nic_info = self.getNicInfo(self.client)
 
-        self.lg('get nic info using g8os client')
-        g8os_nic_info = self.client.info.nic()
+        self.lg('get nic info using zos client')
+        zos_nic_info = self.client.info.nic()
 
-        self.lg('compare g8os/container results to bash results')
+        self.lg('compare zos/container results to bash results')
         params_to_check = ['name', 'addrs', 'mtu', 'hardwareaddr']
         for i in range(len(expected_nic_info) - 1):
             for param in params_to_check:
-                self.assertEqual(expected_nic_info[i][param], g8os_nic_info[i][param])
+                self.assertEqual(expected_nic_info[i][param], zos_nic_info[i][param])
 
         self.lg('{} ENDED'.format(self._testID))
 
     @parameterized.expand(['client', 'container'])
     def test008_mkdir_exists_list_chmod_move_remove_directory(self, client_type):
-        """ g8os-015
+        """ zos-015
         *Test case for test filesystem mkdir, exists, list, chmod, move, remove methods*
 
         **Test Scenario:**
@@ -427,7 +461,7 @@ class SystemTests(BaseTest):
     @parameterized.expand(['client', 'container'])
     def test009_open_close_read_write_file(self, client_type):
 
-        """ g8os-019
+        """ zos-019
         *Test case for test filesystem upload, download, upload_file, download_file methods*
 
         **Test Scenario:**
@@ -562,13 +596,13 @@ class SystemTests(BaseTest):
     @parameterized.expand(['client', 'container'])
     def test010_upload_download_file(self, client_type):
 
-        """ g8os-018
+        """ zos-018
         *Test case for test filesystem upload, download, upload_file, download_file methods*
 
         **Test Scenario:**
         #. Create local file (LF1) and write data to it, should succeed
-        #. Upload file (LF1) to g8os/container
-        #. Check file (LF1) exists in g8os/container and check its data
+        #. Upload file (LF1) to zos/container
+        #. Check file (LF1) exists in zos/container and check its data
         #. Upload buffer data to the remote file
         #. Check the remote file content equal to buffer content
         #. Create remote file (RF1) and write data to it, should succeed
@@ -594,10 +628,10 @@ class SystemTests(BaseTest):
         with open(local_file_name, 'w+') as f:
             f.write(test_txt)
 
-        self.lg('Upload file (LF1) to g8os/container')
+        self.lg('Upload file (LF1) to zos/container')
         client.filesystem.upload_file('/{}'.format(remote_file_name), local_file_name)
 
-        self.lg('Check file (LF1) is exists in g8os/container and check its data')
+        self.lg('Check file (LF1) is exists in zos/container and check its data')
         ls = client.bash('ls').get().stdout.splitlines()
         self.assertIn(remote_file_name, ls)
         file_text = client.bash('cat {}'.format(remote_file_name)).get().stdout.strip()
@@ -645,7 +679,7 @@ class SystemTests(BaseTest):
 
     def test011_kill_list_jobs(self):
 
-        """ g8os-032
+        """ zos-032
         *Test case for testing killing and listing jobs*
 
         **Test Scenario:**
@@ -677,7 +711,7 @@ class SystemTests(BaseTest):
 
     def test012_add_delete_list_addr(self):
 
-        """ g8os-038
+        """ zos-038
         *Test case for testing adding, deleteing and listing ip addresses*
 
         **Test Scenario:**
@@ -727,7 +761,7 @@ class SystemTests(BaseTest):
 
     def test013_link_up_down_list_rename(self):
 
-        """ g8os-039
+        """ zos-039
         *Test case for testing adding, deleteing and listing ip addresses*
 
         **Test Scenario:**
@@ -766,7 +800,7 @@ class SystemTests(BaseTest):
 
     def test014_add_delete_interface_bridge(self):
 
-        """ g8os-040
+        """ zos-040
         *Test case for testing adding, deleteing bridges and their interfaces*
 
         **Test Scenario:**
@@ -818,7 +852,7 @@ class SystemTests(BaseTest):
 
     def test015_add_delete_list_route(self):
 
-        """ g8os-041
+        """ zos-041
         *Test case for testing adding, deleteing and listing routes*
 
         **Test Scenario:**
@@ -863,7 +897,7 @@ class SystemTests(BaseTest):
 
     def test016_open_drop_list_nft(self):
 
-        """ g8os-042
+        """ zos-042
         *Test case for testing opening, droping ports and listing rules*
 
         **Test Scenario:**
@@ -908,7 +942,7 @@ class SystemTests(BaseTest):
 
     def test017_add_list_remove_tasks_cgroups(self):
 
-        """ g8os-046
+        """ zos-046
         *Test case for adding, listing and removing tasks for cgroups*
 
         **Test Scenario:**
@@ -953,7 +987,7 @@ class SystemTests(BaseTest):
     @unittest.skip('https://github.com/zero-os/0-core/issues/702')
     def test018_add_list_remove_cgroup_subsystem(self):
 
-        """ g8os-047
+        """ zos-047
         *Test case for adding, listing and removing subsystem*
 
         **Test Scenario:**
@@ -1005,28 +1039,27 @@ class SystemTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test019_dmi_bios_info(self):
-        """ g8os-048
+        """ zos-048
         *Test case for checking on the dmi BIOS information*
 
         **Test Scenario:**
-        #. Get the dmi bios information using g8os client
+        #. Get the dmi bios information using zos client
         #. Get the information using bash
-        #. Compare dmi g8os results to that of the bash results, should be the same
+        #. Compare dmi zos results to that of the bash results, should be the same
         """
         self.lg('get dmi_bios info using linux bash command (dmidecode -t bios)')
-        dmi_bois_info = self.getDmibiosInfo(self.client)
+        dmi_bios_info = self.get_dmi_bios_info(self.client)
 
-        self.lg('get dmi_bios info using g8os client')
+        self.lg('get dmi_bios info using zos client')
         bios_info = self.client.info.dmi('bios')['BIOS Information']['properties']
 
-        for k in dmi_bois_info.keys():
-            bios_info_value = bios_info[k]['value']
-            self.assertEqual(dmi_bois_info[k],bios_info_value)
+        for k in dmi_bios_info:
+            self.assertEqual(dmi_bios_info[k],bios_info[k]['value'])
             
 
     @parameterized.expand(['client', 'container'])
     def test020_mkdir_chown_remove_directory(self, client_type):
-        """ g8os-049
+        """ zos-049
         *Test case for testing filesystem mkdir and chown methods*
 
         **Test Scenario:**
@@ -1073,7 +1106,7 @@ class SystemTests(BaseTest):
         self.assertEqual(group_owner_1, 'root')
 
         self.lg('Change directory (D1) user owner and group owner to the new user (U1) using filesystem chown method')
-        client.filesystem.chown('{}'.format(dir_name), '{}'.format(new_user), '{}'.format(new_user))
+        client.filesystem.chown(dir_name, new_user, new_user)
 
         self.lg('Get user owner and group owner using bash')
         user_owner_2 = client.bash('stat -c %U {}'.format(dir_name)).get().stdout.splitlines()[0]
@@ -1091,3 +1124,52 @@ class SystemTests(BaseTest):
         self.lg('Remove user (U1), should succeed')
         state = client.bash('deluser {}'.format(new_user)).get().state
         self.assertEqual(state, 'SUCCESS')
+
+
+    def test021_tcp_port_info(self):
+        """ zos-051
+        *Test case for checking on tcp port information*
+
+        **Test Scenario:**
+        #. Get port information using zos client
+        #. Get port information using bash
+        #. Compare port zos results to that of the bash results, should be the same
+        """
+        self.lg('Get port information using zos client')
+        port_info_1 = self.client.info.port()
+
+        self.lg('Get port information using bash (netstat)')
+        port_info_2 = self.get_port_info(self.client, 'tcp')
+
+        self.lg('Compare port zos results to that of the bash results, should be the same')
+        # check ip, port and pid are the same
+        for idx in range(0 ,len(port_info_2['ip'])):
+            self.assertEqual(port_info_1[idx]['ip'], port_info_2['ip'][idx])
+            self.assertEqual(port_info_1[idx]['port'], int(port_info_2['port'][idx]))
+            self.assertEqual(port_info_1[idx]['pid'], int(port_info_2['pid'][idx]))
+        
+
+    def test022_udp_port_info(self):
+        """ zos-052
+        *Test case for checking on udp port information*
+
+        **Test Scenario:**
+        #. Get port information using zos client
+        #. Get port information using bash
+        #. Compare port zos results to that of the bash results, should be the same
+        """
+        self.lg('Get port information using zos client')
+        port_info_1 = self.client.info.port()
+
+        self.lg('Get port information using bash (netstat)')
+        port_info_2 = self.get_port_info(self.client, 'udp')
+
+        for i,n in enumerate(port_info_1):
+            if n['network']=='udp':
+                start = i 
+                break
+
+        for idx in range(0 ,len(port_info_2['ip'])):
+            self.assertEqual(port_info_1[idx + start]['ip'], port_info_2['ip'][idx])
+            self.assertEqual(port_info_1[idx + start]['port'], int(port_info_2['port'][idx]))
+            self.assertEqual(port_info_1[idx + start]['pid'], int(port_info_2['pid'][idx]))

--- a/tests/testsuite/a_basic/tests_02_machines.py
+++ b/tests/testsuite/a_basic/tests_02_machines.py
@@ -7,11 +7,11 @@ class Machinetests(BaseTest):
 
     def setUp(self):
         super(Machinetests, self).setUp()
-        self.check_g8os_connection(Machinetests)
+        self.check_zos_connection(Machinetests)
 
     @unittest.skip("this test doesn't work on travis .. no idea why.. needs to be run manually")
     def test001_create_destroy_list_kvm(self):
-        """ g8os-009
+        """ zos-009
 
         *Test case for testing creating, listing and destroying VMs*
 
@@ -65,7 +65,7 @@ class Machinetests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test002_create_list_delete_containers(self):
-        """ g8os-010
+        """ zos-010
         *Test case for testing creating, listing and deleting containers*
 
         **Test Scenario:**
@@ -101,7 +101,7 @@ class Machinetests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test003_deal_with_container_client(self):
-        """ g8os-011
+        """ zos-011
 
         *Test case for testing dealing with container client*
 
@@ -111,7 +111,7 @@ class Machinetests(BaseTest):
         #. Get container(C1) client
         #. Use container client  to create  folder using system, should succeed
         #. Use container client to check folder is exist using bash
-        #. Use G8os client to check the folder is created only in container
+        #. Use zos client to check the folder is created only in container
         #. Use container client to delete created folder
         #. Destroy C1, should succeed
 
@@ -150,7 +150,7 @@ class Machinetests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test004_pause_resume_get_kvm(self):
-        """ g8os-050
+        """ zos-050
 
         *Test case for testing pausing resuming VMs*
 
@@ -165,6 +165,7 @@ class Machinetests(BaseTest):
         vm_name = self.rand_str()
         self.lg('- Create virtual machine {} , should succeed'.format(vm_name))
         vm_uuid = self.create_vm(name=vm_name)
+        time.sleep(3)
 
         self.lg('Pause the VM and check state from get method ,should be paused')
         self.client.kvm.pause(vm_uuid)

--- a/tests/testsuite/a_basic/tests_03_networking.py
+++ b/tests/testsuite/a_basic/tests_03_networking.py
@@ -7,10 +7,10 @@ class BasicNetworking(BaseTest):
 
     def setUp(self):
         super(BasicNetworking, self).setUp()
-        self.check_g8os_connection(BasicNetworking)
+        self.check_zos_connection(BasicNetworking)
 
     def test001_join_leave_list_zerotier(self):
-        """ g8os-012
+        """ zos-012
         *Test case for testing joining, listing, leaving zerotier networks*
 
         **Test Scenario:**
@@ -55,7 +55,7 @@ class BasicNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test002_create_delete_list_bridges(self):
-        """ g8os-013
+        """ zos-013
         *Test case for testing creating, listing, deleting bridges*
 
         **Test Scenario:**
@@ -94,7 +94,7 @@ class BasicNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test003_add_remove_list_nics_for_bridge(self):
-        """ g8os-045
+        """ zos-045
         *Test case for adding, removing and listing nics for a bridges*
 
         **Test Scenario:**

--- a/tests/testsuite/b_extended/tests_01_disks.py
+++ b/tests/testsuite/b_extended/tests_01_disks.py
@@ -6,7 +6,7 @@ class DisksTests(BaseTest):
 
     def setUp(self):
         super(DisksTests, self).setUp()
-        self.check_g8os_connection(DisksTests)
+        self.check_zos_connection(DisksTests)
 
     def create_btrfs(self, second_btrfs=False):
         self.lg('Create Btrfs file system (Bfs1), should succeed')
@@ -59,7 +59,7 @@ class DisksTests(BaseTest):
         return diskinf
 
     def test001_create_list_delete_btrfs(self):
-        """ g8os-008
+        """ zos-008
         *Test case for creating, listing and monitoring btrfs*
 
         **Test Scenario:**
@@ -110,7 +110,7 @@ class DisksTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test002_subvolumes_btrfs(self):
-        """ g8os-016
+        """ zos-016
         *Test case for creating, listing and deleting btrfs subvolumes*
 
         **Test Scenario:**
@@ -168,7 +168,7 @@ class DisksTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test003_snapshots_btrfs(self):
-        """ g8os-017
+        """ zos-017
         *Test case for creating, listing and deleting btrfs snapshots*
 
         **Test Scenario:**
@@ -220,7 +220,7 @@ class DisksTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test004_disk_get_info(self):
-        """ g8os-020
+        """ zos-020
 
         *Test case for checking on the disks information*
 
@@ -228,8 +228,8 @@ class DisksTests(BaseTest):
 
         #. Get the disks name  using disk list
         #. Get disk info using bash
-        #. Get disk info using g8os disk info
-        #. Compare g8os results to that of the bash results, should be the same
+        #. Get disk info using zos disk info
+        #. Compare zos results to that of the bash results, should be the same
 
         """
         self.lg('{} STARTED'.format(self._testID))
@@ -242,17 +242,17 @@ class DisksTests(BaseTest):
 
         for disk in disks_names:
 
-            self.lg('Get disk {} info  using g8os disk info  '.format(disk))
-            g8os_disk_info = self.client.disk.getinfo(disk)
-            keys = g8os_disk_info.keys()
+            self.lg('Get disk {} info  using zos disk info  '.format(disk))
+            zos_disk_info = self.client.disk.getinfo(disk)
+            keys = zos_disk_info.keys()
 
             self.lg('Get disk {} info  using bash '.format(disk))
             bash_disk_info = self.bash_disk_info(keys, disk)
 
-            self.lg('compare g8os results to disk{} of the bash results, should be the same '.format(disk))
-            for key in g8os_disk_info.keys():
+            self.lg('compare zos results to disk{} of the bash results, should be the same '.format(disk))
+            for key in zos_disk_info.keys():
                 if key in bash_disk_info.keys():
-                    v = g8os_disk_info[key]
+                    v = zos_disk_info[key]
                     if v is None:
                         v = ''
                     if isinstance(v, str):
@@ -262,14 +262,14 @@ class DisksTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test005_disk_mount_and_unmount(self):
-        """ g8os-021
+        """ zos-021
 
         *Test case for test mount disk and unmount *
 
         **Test Scenario:**
 
         #. create loop device and put file system on it
-        #. Mount disk using g8os disk mount.
+        #. Mount disk using zos disk mount.
         #. Get disk info , the mounted disk should be there.
         #. Try mount it again , should fail.
         #. unmount the disk, shouldn't be found in the disks list
@@ -279,12 +279,12 @@ class DisksTests(BaseTest):
         filename = [self.rand_str()]
         label = self.rand_str()
         mount_point = '/mnt/{}'.format(self.rand_str())
-        self.lg('Mount disk using g8os disk mount.')
+        self.lg('Mount disk using zos disk mount.')
         loop_dev_list = self.setup_loop_devices(filename, '500M', deattach=True)
 
         self.client.btrfs.create(label, loop_dev_list)
 
-        self.lg('Mount disk using g8os disk mount')
+        self.lg('Mount disk using zos disk mount')
         self.client.bash('mkdir -p {}'.format(mount_point))
         self.client.disk.mount(loop_dev_list[0], mount_point,[""])
 
@@ -311,7 +311,7 @@ class DisksTests(BaseTest):
 
     def test006_disk_partitions(self):
 
-        """ g8os-022
+        """ zos-022
 
         *Test case for test creating Partitions in disk *
 
@@ -369,7 +369,7 @@ class DisksTests(BaseTest):
 
     def test007_extended_disk_partitions(self):
 
-        """ g8os-025
+        """ zos-025
 
         *Test case for test creating Partitions in disk *
 
@@ -382,7 +382,7 @@ class DisksTests(BaseTest):
         #. Make extended partition with remain disk space ,should succeed.
         #. Divide extended partition to logical partition ,should succeed .
         #. Check disk  exist in disk list with 2 partition.
-        #. Mount partition 1 and 2 of disk  using g8os disk mount with rw option , should succeed.
+        #. Mount partition 1 and 2 of disk  using zos disk mount with rw option , should succeed.
         #. Get disk info, check the mounted point for partition.
         #. Remove mounted partition ,should fail
         #. Unmount the partition1, should succeed.
@@ -421,12 +421,12 @@ class DisksTests(BaseTest):
             if disk['name'] == device_name:
                 self.assertEqual(len(disk['children']), 2)
 
-        self.lg('Mount partition 1 of disk  using g8os disk mount with rw option , should succeed')
+        self.lg('Mount partition 1 of disk  using zos disk mount with rw option , should succeed')
         self.client.btrfs.create(label, ['{}p1'.format(loop_dev_list[0])])
         self.client.bash('mkdir -p {}'.format(mount_point_part1))
         self.client.disk.mount('{}p1'.format(loop_dev_list[0]), mount_point_part1, ["rw"])
 
-        self.lg('Mount partition 2 of disk  using g8os disk mount with rw option , should succeed')
+        self.lg('Mount partition 2 of disk  using zos disk mount with rw option , should succeed')
         self.client.btrfs.create(label, ['{}p5'.format(loop_dev_list[0])])
         self.client.bash('mkdir -p {}'.format(mount_point_part2))
         self.client.disk.mount('{}p5'.format(loop_dev_list[0]), mount_point_part2, ["rw"])
@@ -452,7 +452,7 @@ class DisksTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test008_quota_btrfs(self):
-        """ g8os-026
+        """ zos-026
         *Test case for btrfs quota*
 
         **Test Scenario:**
@@ -489,7 +489,7 @@ class DisksTests(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test009_btrfs_add_remove_devices(self):
-        """ g8os-034
+        """ zos-034
         *Test case for adding and removing devices for btrfs *
 
         **Test Scenario:**

--- a/tests/testsuite/b_extended/tests_02_machines.py
+++ b/tests/testsuite/b_extended/tests_02_machines.py
@@ -7,7 +7,7 @@ class ExtendedMachines(BaseTest):
 
     def __init__(self, *args, **kwargs):
         super(ExtendedMachines, self).__init__(*args, **kwargs)
-        self.check_g8os_connection(ExtendedMachines)
+        self.check_zos_connection(ExtendedMachines)
         containers = self.client.container.find('ovs')
         ovs_exist = [key for key, value in containers.items()]
         if not ovs_exist:
@@ -22,10 +22,10 @@ class ExtendedMachines(BaseTest):
 
     def setUp(self):
         super(ExtendedMachines, self).setUp()
-        self.check_g8os_connection(ExtendedMachines)
+        self.check_zos_connection(ExtendedMachines)
 
     def test001_kvm_add_remove_nics(self):
-        """ g8os-035
+        """ zos-035
 
         *Test case for testing adding and removing nics for vms*
 
@@ -90,7 +90,7 @@ class ExtendedMachines(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test002_kvm_attach_deattach_disks(self):
-        """ g8os-036
+        """ zos-036
 
         *Test case for testing attaching and deattaching disks for vms*
 
@@ -139,7 +139,7 @@ class ExtendedMachines(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test_003_containers_backup_restore(self):
-        """ g8os-037
+        """ zos-037
 
         *Test case for container backup and restore*
 
@@ -205,7 +205,7 @@ class ExtendedMachines(BaseTest):
 
     @unittest.skip('https://github.com/zero-os/0-core/issues/679')
     def test_004_container_passthrough_nic(self):
-        """ g8os-043
+        """ zos-043
 
         *Test case for testing nic of type passthrough of a container*
 
@@ -265,7 +265,7 @@ class ExtendedMachines(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test_005_containers_macvlan_nic(self):
-        """ g8os-044
+        """ zos-044
 
         *Test case for testing nic of type macvlan*
 

--- a/tests/testsuite/b_extended/tests_03_networking.py
+++ b/tests/testsuite/b_extended/tests_03_networking.py
@@ -8,14 +8,14 @@ class ExtendedNetworking(BaseTest):
 
     def setUp(self):
         super(ExtendedNetworking, self).setUp()
-        self.check_g8os_connection(ExtendedNetworking)
+        self.check_zos_connection(ExtendedNetworking)
 
     def rand_mac_address(self):
         mac_addr = ["{:02X}".format(randint(0, 255)) for x in range(6)]
         return ':'.join(mac_addr)
 
     def test001_zerotier(self):
-        """ g8os-014
+        """ zos-014
         *Test case for testing zerotier functionally*
 
         **Test Scenario:**
@@ -66,7 +66,7 @@ class ExtendedNetworking(BaseTest):
 
     def test002_create_bridges_with_specs_hwaddr(self):
 
-        """ g8os-023
+        """ zos-023
         *Test case for testing creating, listing, deleting bridges*
 
         **Test Scenario:**
@@ -108,7 +108,7 @@ class ExtendedNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test003_create_bridges_with_specs_network(self):
-        """ g8os-024
+        """ zos-024
         *Test case for testing creating, listing, deleting bridges*
 
         **Test Scenario:**
@@ -176,7 +176,7 @@ class ExtendedNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test004_attach_bridge_to_container(self):
-        """ g8os-027
+        """ zos-027
         *Test case for testing creating, listing, deleting bridges*
 
         **Test Scenario:**
@@ -249,7 +249,7 @@ class ExtendedNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test005_create_bridges_with_specs_nat(self):
-        """ g8os-028
+        """ zos-028
         *Test case for testing creating, listing, deleting bridges*
 
         **Test Scenario:**

--- a/tests/testsuite/c_advanced/tests_03_networking.py
+++ b/tests/testsuite/c_advanced/tests_03_networking.py
@@ -9,7 +9,7 @@ import unittest
 class AdvancedNetworking(BaseTest):
     def setUp(self):
         super(AdvancedNetworking, self).setUp()
-        self.check_g8os_connection(AdvancedNetworking)
+        self.check_zos_connection(AdvancedNetworking)
         containers = self.client.container.find('ovs')
         ovs_exist = [key for key, value in containers.items()]
         if not ovs_exist:
@@ -24,7 +24,7 @@ class AdvancedNetworking(BaseTest):
 
 
     def test001_vxlans_connections(self):
-        """ g8os-029
+        """ zos-029
         *Test case for testing vxlans connections*
 
         **Test Scenario:**
@@ -93,7 +93,7 @@ class AdvancedNetworking(BaseTest):
 
     @unittest.skip('line 123 has a problem related to packet machines locations.. please execute it manually')
     def test002_vlans_connections(self):
-        """ g8os-030
+        """ zos-030
         *Test case for testing vlans connections*
 
         **Test Scenario:**
@@ -180,7 +180,7 @@ class AdvancedNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test003_vxlan_vlan_connections(self):
-        """ g8os-031
+        """ zos-031
         *Test case for testing vxlans-vlans connections*
 
         **Test Scenario:**
@@ -229,7 +229,7 @@ class AdvancedNetworking(BaseTest):
         self.lg('{} ENDED'.format(self._testID))
 
     def test004_create_multiple_vlans_vxlan(self):
-        """ g8os-033
+        """ zos-033
         *Test case for creating multiple vlans and vxlans*
 
         **Test Scenario:**

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -2,10 +2,10 @@ import logging
 import os
 
 # Start testsuite logger
-logger = logging.getLogger('g8os_testsuite')
-if not os.path.exists('logs/g8os_testsuite.log'):
+logger = logging.getLogger('zos_testsuite')
+if not os.path.exists('logs/zos_testsuite.log'):
     os.mkdir('logs')
-handler = logging.FileHandler('logs/g8os_testsuite.log')
+handler = logging.FileHandler('logs/zos_testsuite.log')
 formatter = logging.Formatter('%(asctime)s [%(testid)s] [%(levelname)s] %(message)s',
                               '%d-%m-%Y %H:%M:%S %Z')
 handler.setFormatter(formatter)

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -28,7 +28,7 @@ class BaseTest(unittest.TestCase):
     def setUp(self):
         self._testID = self._testMethodName
         self._startTime = time.time()
-        self._logger = logging.LoggerAdapter(logging.getLogger('g8os_testsuite'),
+        self._logger = logging.LoggerAdapter(logging.getLogger('zos_testsuite'),
                                              {'testid': self.shortDescription() or self._testID})
 
 
@@ -38,12 +38,12 @@ class BaseTest(unittest.TestCase):
     def lg(self, msg):
         self._logger.info(msg)
 
-    def check_g8os_connection(self, classname):
+    def check_zos_connection(self, classname):
         try:
             self.client.ping()
         except Exception as e:
-            self.lg("can't reach g8os remote machine")
-            print("Can't reach g8os remote machine")
+            self.lg("can't reach zos remote machine")
+            print("Can't reach zos remote machine")
             self.skipTest(classname)
 
     def rand_str(self):
@@ -122,9 +122,9 @@ class BaseTest(unittest.TestCase):
             self.lg('can\'t connect to zerotier, {}:{}'.format(r.status_code, r.content))
             return False
 
-    def get_g8os_zt_ip(self, networkId):
+    def get_zos_zt_ip(self, networkId):
         """
-        method to get the zerotier ip address of the g8os client
+        method to get the zerotier ip address of the zos client
         """
         nws = self.client.zerotier.list()
         for nw in nws:
@@ -136,7 +136,7 @@ class BaseTest(unittest.TestCase):
 
     def get_contanier_zt_ip(self, client, networkId):
         """
-        method to get zerotier ip address of the g8os container
+        method to get zerotier ip address of the zos container
         Note: to use this method, make sure that zt is defined first in the nic
         list during creating your container, so it could be attached to etho interface
         """


### PR DESCRIPTION
Replace g8os with zos.

Test case for checking on tcp port information:
 - Get port information using zos client.
 - Get port information using bash.
 - Compare port zos results to that of the bash results, should be the same.
![screenshot from 2018-08-23 11-26-53](https://user-images.githubusercontent.com/41957921/44517673-9a779b80-a6c8-11e8-9fbb-b4a976fbd1ef.png)

Test case for checking on udp port information:
 - Get port information using zos client.
 - Get port information using bash.
 - Compare port zos results to that of the bash results, should be the same.
![screenshot from 2018-08-23 11-27-38](https://user-images.githubusercontent.com/41957921/44517701-ae230200-a6c8-11e8-9ab1-379ee7e12482.png)