### PR TITLE
Process output messages improvements

### DIFF
--- a/base/pm/runnerhook.go
+++ b/base/pm/runnerhook.go
@@ -118,9 +118,6 @@ type StreamHook struct {
 }
 
 func (h *StreamHook) append(buf *bytes.Buffer, msg *stream.Message) {
-	if buf.Len() > 0 {
-		buf.WriteByte('\n')
-	}
 	buf.WriteString(msg.Message)
 }
 

--- a/base/pm/stream/consumer_test.go
+++ b/base/pm/stream/consumer_test.go
@@ -209,3 +209,48 @@ func TestConsumerNoNewLine(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestConsumer_ParseHeader(t *testing.T) {
+	var c consumerImpl
+	head, err := c.parseHead([]byte("1::"))
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, &header{level: 1, length: 3}, head); !ok {
+		t.Error()
+	}
+
+	head, err = c.parseHead([]byte("12::abc"))
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, &header{level: 12, length: 4}, head); !ok {
+		t.Error()
+	}
+
+	head, err = c.parseHead([]byte("12:::abc"))
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, &header{level: 12, length: 5, multiline: true}, head); !ok {
+		t.Error()
+	}
+
+	head, err = c.parseHead([]byte("1:"))
+
+	if ok := assert.Error(t, err); !ok {
+		t.Fatal()
+	}
+
+	head, err = c.parseHead([]byte(""))
+
+	if ok := assert.Error(t, err); !ok {
+		t.Fatal()
+	}
+}

--- a/base/pm/stream/consumer_test.go
+++ b/base/pm/stream/consumer_test.go
@@ -2,7 +2,6 @@ package stream
 
 import (
 	"io"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,19 +31,45 @@ func (_ *testReader) Close() error {
 	return nil
 }
 
-func TestConsumer_OneLine(t *testing.T) {
+func TestConsumer_newLineOrEOF(t *testing.T) {
+	c := consumerImpl{}
+	s := "hello world"
+	x := c.newLineOrEOF([]byte(s))
+	if ok := assert.Equal(t, 11, x); !ok {
+		t.Fail()
+	}
+
+	s = "hello\nworld"
+	x = c.newLineOrEOF([]byte(s))
+	if ok := assert.Equal(t, 5, x); !ok {
+		t.Fail()
+	}
+
+	b := []byte("hello\nworld")
+	var r []string
+	for i := 0; i < len(b); i++ {
+		n := c.newLineOrEOF(b[i:])
+		r = append(r, string(b[i:i+n]))
+		i += n
+	}
+
+	if ok := assert.Equal(t, []string{"hello", "world"}, r); !ok {
+		t.Fail()
+	}
+}
+
+func TestConsumer_processNormalText(t *testing.T) {
 	var message *Message
 	h := func(m *Message) {
 		message = m
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	Consume(&wg, &testReader{
-		chunks: []string{"hello world\n"},
-	}, 1, h)
+	c := consumerImpl{
+		level:   1,
+		handler: h,
+	}
 
-	wg.Wait()
+	c.process([]byte("hello world"))
 
 	if ok := assert.NotNil(t, message); !ok {
 		t.Fatal()
@@ -57,110 +82,48 @@ func TestConsumer_OneLine(t *testing.T) {
 	if ok := assert.Equal(t, uint16(1), message.Meta.Level()); !ok {
 		t.Fatal()
 	}
+
+	message = nil
+	txt := "hello world\nthis is output of some program\nthat spans many lines\n"
+	c.process([]byte(txt))
+
+	if ok := assert.NotNil(t, message); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, txt, message.Message); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, uint16(1), message.Meta.Level()); !ok {
+		t.Fatal()
+	}
 }
 
-func TestConsumer_TwoLines(t *testing.T) {
+func TestConsumer_processSingleLineMessage(t *testing.T) {
 	var messages []*Message
 	h := func(m *Message) {
 		messages = append(messages, m)
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	Consume(&wg, &testReader{
-		chunks: []string{
-			"hello world\n",
-			"10::bye bye world\n",
-		},
-	}, 1, h)
+	c := consumerImpl{
+		level:   1,
+		handler: h,
+	}
 
-	wg.Wait()
+	c.process([]byte(`hello world
+the folowing line is a single line message
+2::this is a single line message`))
 
 	if ok := assert.Len(t, messages, 2); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "hello world", messages[0].Message); !ok {
+	if ok := assert.Equal(t, "hello world\nthe folowing line is a single line message\n", messages[0].Message); !ok {
 		t.Error()
 	}
 
 	if ok := assert.Equal(t, uint16(1), messages[0].Meta.Level()); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, "bye bye world", messages[1].Message); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, uint16(10), messages[1].Meta.Level()); !ok {
-		t.Error()
-	}
-}
-
-func TestConsumer_MultiLine(t *testing.T) {
-	var messages []*Message
-	h := func(m *Message) {
-		messages = append(messages, m)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	Consume(&wg, &testReader{
-		chunks: []string{
-			"30:::hello\nworld\n",
-			":::\n",
-		},
-	}, 1, h)
-
-	wg.Wait()
-
-	if ok := assert.Len(t, messages, 1); !ok {
-		t.Fatal()
-	}
-
-	if ok := assert.Equal(t, "hello\nworld", messages[0].Message); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, uint16(30), messages[0].Meta.Level()); !ok {
-		t.Error()
-	}
-}
-
-func TestConsumer_Complex(t *testing.T) {
-	var messages []*Message
-	h := func(m *Message) {
-		messages = append(messages, m)
-	}
-
-	chunk1 := `Hello world
-20::this is a single line message
-30:::but this is a multi line
-that spans`
-
-	chunk2 := ` two blocks of data
-:::
-`
-	var wg sync.WaitGroup
-	wg.Add(1)
-	Consume(&wg, &testReader{
-		chunks: []string{
-			chunk1,
-			chunk2,
-		},
-	}, 2, h)
-
-	wg.Wait()
-
-	if ok := assert.Len(t, messages, 3); !ok {
-		t.Fatal()
-	}
-
-	if ok := assert.Equal(t, "Hello world", messages[0].Message); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, uint16(2), messages[0].Meta.Level()); !ok {
 		t.Error()
 	}
 
@@ -168,89 +131,266 @@ that spans`
 		t.Error()
 	}
 
-	if ok := assert.Equal(t, uint16(20), messages[1].Meta.Level()); !ok {
+	if ok := assert.Equal(t, uint16(2), messages[1].Meta.Level()); !ok {
 		t.Error()
 	}
 
-	if ok := assert.Equal(t, "but this is a multi line\nthat spans two blocks of data", messages[2].Message); !ok {
-		t.Error()
-	}
+	messages = nil
 
-	if ok := assert.Equal(t, uint16(30), messages[2].Meta.Level()); !ok {
-		t.Error()
-	}
-}
+	c.process([]byte(`hello world
+the folowing line is a single line message
+2::this is a single line message
+followed by some more text
+that spans multiple lines`))
 
-func TestConsumerNoNewLine(t *testing.T) {
-	var messages []*Message
-	h := func(m *Message) {
-		messages = append(messages, m)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	Consume(&wg, &testReader{
-		chunks: []string{
-			"hello world",
-		},
-	}, 1, h)
-
-	wg.Wait()
-
-	if ok := assert.Len(t, messages, 1); !ok {
+	if ok := assert.Len(t, messages, 3); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "hello world", messages[0].Message); !ok {
-		t.Fatal()
+	if ok := assert.Equal(t, "hello world\nthe folowing line is a single line message\n", messages[0].Message); !ok {
+		t.Error()
 	}
 
 	if ok := assert.Equal(t, uint16(1), messages[0].Meta.Level()); !ok {
-		t.Fatal()
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "this is a single line message", messages[1].Message); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, uint16(2), messages[1].Meta.Level()); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "followed by some more text\nthat spans multiple lines", messages[2].Message); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, uint16(1), messages[2].Meta.Level()); !ok {
+		t.Error()
 	}
 }
 
-func TestConsumer_ParseHeader(t *testing.T) {
-	var c consumerImpl
-	head, err := c.parseHead([]byte("1::"))
+// func TestConsumer_OneLine(t *testing.T) {
+// 	var message *Message
+// 	h := func(m *Message) {
+// 		message = m
+// 	}
 
-	if ok := assert.NoError(t, err); !ok {
-		t.Fatal()
-	}
+// 	var wg sync.WaitGroup
+// 	wg.Add(1)
+// 	Consume(&wg, &testReader{
+// 		chunks: []string{"hello world\n"},
+// 	}, 1, h)
 
-	if ok := assert.Equal(t, &header{level: 1, length: 3}, head); !ok {
-		t.Error()
-	}
+// 	wg.Wait()
 
-	head, err = c.parseHead([]byte("12::abc"))
+// 	if ok := assert.NotNil(t, message); !ok {
+// 		t.Fatal()
+// 	}
 
-	if ok := assert.NoError(t, err); !ok {
-		t.Fatal()
-	}
+// 	if ok := assert.Equal(t, "hello world", message.Message); !ok {
+// 		t.Fatal()
+// 	}
 
-	if ok := assert.Equal(t, &header{level: 12, length: 4}, head); !ok {
-		t.Error()
-	}
+// 	if ok := assert.Equal(t, uint16(1), message.Meta.Level()); !ok {
+// 		t.Fatal()
+// 	}
+// }
 
-	head, err = c.parseHead([]byte("12:::abc"))
+// func TestConsumer_TwoLines(t *testing.T) {
+// 	var messages []*Message
+// 	h := func(m *Message) {
+// 		messages = append(messages, m)
+// 	}
 
-	if ok := assert.NoError(t, err); !ok {
-		t.Fatal()
-	}
+// 	var wg sync.WaitGroup
+// 	wg.Add(1)
+// 	Consume(&wg, &testReader{
+// 		chunks: []string{
+// 			"hello world\n",
+// 			"10::bye bye world\n",
+// 		},
+// 	}, 1, h)
 
-	if ok := assert.Equal(t, &header{level: 12, length: 5, multiline: true}, head); !ok {
-		t.Error()
-	}
+// 	wg.Wait()
 
-	head, err = c.parseHead([]byte("1:"))
+// 	if ok := assert.Len(t, messages, 2); !ok {
+// 		t.Fatal()
+// 	}
 
-	if ok := assert.Error(t, err); !ok {
-		t.Fatal()
-	}
+// 	if ok := assert.Equal(t, "hello world", messages[0].Message); !ok {
+// 		t.Error()
+// 	}
 
-	head, err = c.parseHead([]byte(""))
+// 	if ok := assert.Equal(t, uint16(1), messages[0].Meta.Level()); !ok {
+// 		t.Error()
+// 	}
 
-	if ok := assert.Error(t, err); !ok {
-		t.Fatal()
-	}
-}
+// 	if ok := assert.Equal(t, "bye bye world", messages[1].Message); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, uint16(10), messages[1].Meta.Level()); !ok {
+// 		t.Error()
+// 	}
+// }
+
+// func TestConsumer_MultiLine(t *testing.T) {
+// 	var messages []*Message
+// 	h := func(m *Message) {
+// 		messages = append(messages, m)
+// 	}
+
+// 	var wg sync.WaitGroup
+// 	wg.Add(1)
+// 	Consume(&wg, &testReader{
+// 		chunks: []string{
+// 			"30:::hello\nworld\n",
+// 			":::\n",
+// 		},
+// 	}, 1, h)
+
+// 	wg.Wait()
+
+// 	if ok := assert.Len(t, messages, 1); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, "hello\nworld", messages[0].Message); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, uint16(30), messages[0].Meta.Level()); !ok {
+// 		t.Error()
+// 	}
+// }
+
+// func TestConsumer_Complex(t *testing.T) {
+// 	var messages []*Message
+// 	h := func(m *Message) {
+// 		messages = append(messages, m)
+// 	}
+
+// 	chunk1 := `Hello world
+// 20::this is a single line message
+// 30:::but this is a multi line
+// that spans`
+
+// 	chunk2 := ` two blocks of data
+// :::
+// `
+// 	var wg sync.WaitGroup
+// 	wg.Add(1)
+// 	Consume(&wg, &testReader{
+// 		chunks: []string{
+// 			chunk1,
+// 			chunk2,
+// 		},
+// 	}, 2, h)
+
+// 	wg.Wait()
+
+// 	if ok := assert.Len(t, messages, 3); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, "Hello world", messages[0].Message); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, uint16(2), messages[0].Meta.Level()); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, "this is a single line message", messages[1].Message); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, uint16(20), messages[1].Meta.Level()); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, "but this is a multi line\nthat spans two blocks of data", messages[2].Message); !ok {
+// 		t.Error()
+// 	}
+
+// 	if ok := assert.Equal(t, uint16(30), messages[2].Meta.Level()); !ok {
+// 		t.Error()
+// 	}
+// }
+
+// func TestConsumerNoNewLine(t *testing.T) {
+// 	var messages []*Message
+// 	h := func(m *Message) {
+// 		messages = append(messages, m)
+// 	}
+
+// 	var wg sync.WaitGroup
+// 	wg.Add(1)
+// 	Consume(&wg, &testReader{
+// 		chunks: []string{
+// 			"hello world",
+// 		},
+// 	}, 1, h)
+
+// 	wg.Wait()
+
+// 	if ok := assert.Len(t, messages, 1); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, "hello world", messages[0].Message); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, uint16(1), messages[0].Meta.Level()); !ok {
+// 		t.Fatal()
+// 	}
+// }
+
+// func TestConsumer_ParseHeader(t *testing.T) {
+// 	var c consumerImpl
+// 	head, err := c.parseHead([]byte("1::"))
+
+// 	if ok := assert.NoError(t, err); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, &header{level: 1, length: 3}, head); !ok {
+// 		t.Error()
+// 	}
+
+// 	head, err = c.parseHead([]byte("12::abc"))
+
+// 	if ok := assert.NoError(t, err); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, &header{level: 12, length: 4}, head); !ok {
+// 		t.Error()
+// 	}
+
+// 	head, err = c.parseHead([]byte("12:::abc"))
+
+// 	if ok := assert.NoError(t, err); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	if ok := assert.Equal(t, &header{level: 12, length: 5, multiline: true}, head); !ok {
+// 		t.Error()
+// 	}
+
+// 	head, err = c.parseHead([]byte("1:"))
+
+// 	if ok := assert.Error(t, err); !ok {
+// 		t.Fatal()
+// 	}
+
+// 	head, err = c.parseHead([]byte(""))
+
+// 	if ok := assert.Error(t, err); !ok {
+// 		t.Fatal()
+// 	}
+// }

--- a/base/pm/stream/input.go
+++ b/base/pm/stream/input.go
@@ -2,6 +2,8 @@ package stream
 
 import (
 	"bufio"
+	"bytes"
+	"fmt"
 	"io"
 	"regexp"
 	"strconv"
@@ -11,9 +13,16 @@ import (
 	logging "github.com/op/go-logging"
 )
 
+const (
+	ioBufferSize      = 32 * 1024
+	messageBufferSize = 10 * 1024
+)
+
 var (
 	log             = logging.MustGetLogger("stream")
 	pmMsgPattern, _ = regexp.Compile("^(\\d+)(:{2,3})(.*)$")
+
+	errNotHeader = fmt.Errorf("not header")
 )
 
 type consumerImpl struct {
@@ -25,12 +34,18 @@ type consumerImpl struct {
 	buffer *bufio.Reader
 }
 
+type header struct {
+	level     uint16
+	multiline bool
+	length    int
+}
+
 //Consume consumes a stream to the end, and calls the handler with the parsed stream messages
 func Consume(wg *sync.WaitGroup, source io.ReadCloser, level uint16, handler MessageHandler) {
 	c := &consumerImpl{
 		level:   level,
 		handler: handler,
-		buffer:  bufio.NewReaderSize(source, 32*1024),
+		buffer:  bufio.NewReaderSize(source, ioBufferSize),
 	}
 
 	go func() {
@@ -44,6 +59,51 @@ func Consume(wg *sync.WaitGroup, source io.ReadCloser, level uint16, handler Mes
 
 		source.Close()
 	}()
+}
+
+func (c *consumerImpl) isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+func (c *consumerImpl) parseHead(head []byte) (*header, error) {
+	//parse the header without regex
+	//valid pattern is
+	// `dd?:::?`
+	if len(head) < 3 {
+		return nil, errNotHeader //noway this is a header
+	}
+
+	skip := bytes.Index(head, []byte("::"))
+
+	if skip > 2 || skip <= 0 {
+		return nil, errNotHeader
+	}
+
+	level, _ := strconv.ParseUint(string(head[0:skip]), 10, 16)
+	h := header{
+		level: uint16(level),
+	}
+
+	if bytes.HasPrefix(head[skip:], []byte(":::")) {
+		//multi line
+		h.multiline = true
+		h.length = skip + 3
+	} else if bytes.HasPrefix(head[skip:], []byte("::")) {
+		h.length = skip + 2
+	} else {
+		return nil, errNotHeader
+	}
+
+	return &h, nil
+}
+
+func (c *consumerImpl) readLine(out io.Writer) error {
+	line, err := c.buffer.ReadBytes('\n')
+	if err != nil && err != io.EOF {
+		return err
+	}
+	_, err = out.Write(line)
+	return err
 }
 
 func (c *consumerImpl) consume() error {

--- a/base/pm/stream/input.go
+++ b/base/pm/stream/input.go
@@ -1,7 +1,6 @@
 package stream
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -14,13 +13,14 @@ import (
 )
 
 const (
-	ioBufferSize      = 32 * 1024
-	messageBufferSize = 10 * 1024
+	ioBufferSize = 32 * 1024
+	//messageBufferSize = 10 * 1024
 )
 
 var (
-	log             = logging.MustGetLogger("stream")
-	pmMsgPattern, _ = regexp.Compile("^(\\d+)(:{2,3})(.*)$")
+	log           = logging.MustGetLogger("stream")
+	pmMsgPattern  = regexp.MustCompile("^(\\d+)(:{2,3})(.*)$")
+	headerPattern = regexp.MustCompile(`^(\d+)(:{2,3})`)
 
 	errNotHeader = fmt.Errorf("not header")
 )
@@ -31,7 +31,7 @@ type consumerImpl struct {
 
 	multi *Message
 
-	buffer *bufio.Reader
+	source io.Reader
 }
 
 type header struct {
@@ -45,9 +45,10 @@ func Consume(wg *sync.WaitGroup, source io.ReadCloser, level uint16, handler Mes
 	c := &consumerImpl{
 		level:   level,
 		handler: handler,
-		buffer:  bufio.NewReaderSize(source, ioBufferSize),
+		source:  source,
 	}
 
+	//source.Read
 	go func() {
 		if wg != nil {
 			defer wg.Done()
@@ -97,28 +98,107 @@ func (c *consumerImpl) parseHead(head []byte) (*header, error) {
 	return &h, nil
 }
 
-func (c *consumerImpl) readLine(out io.Writer) error {
-	line, err := c.buffer.ReadBytes('\n')
-	if err != nil && err != io.EOF {
-		return err
+func (c *consumerImpl) getHeaderFromMatch(m [][]byte) *header {
+	level, _ := strconv.ParseUint(string(m[1]), 10, 16)
+	h := header{
+		level: uint16(level),
 	}
-	_, err = out.Write(line)
-	return err
+	if len(m[2]) == 3 {
+		h.multiline = true
+	}
+	h.length = len(m[0])
+	return &h
+}
+
+// func (c *consumerImpl) readLine(out io.Writer) error {
+// 	line, err := c.buffer.ReadBytes('\n')
+// 	if err != nil && err != io.EOF {
+// 		return err
+// 	}
+// 	_, err = out.Write(line)
+// 	return err
+// }
+
+//newLineOrEOF will return index of the next \n or EOF (end of file or string)
+func (c *consumerImpl) newLineOrEOF(b []byte) int {
+	i := 0
+	for ; i < len(b) && b[i] != '\n'; i++ {
+	}
+
+	return i
+}
+
+//process process the buffer and return th
+func (c *consumerImpl) process(buffer []byte) int {
+	start := 0
+	for i := 0; i < len(buffer); i++ {
+		//fmt.Printf("trying: %s\n", string(buffer[i:]))
+		m := headerPattern.FindSubmatch(buffer[i:])
+		if m == nil {
+			//no header was found at this position
+			i += c.newLineOrEOF(buffer[i+1:]) + 1
+			continue
+		}
+
+		//if we reach here then we can safely flush what we have in buffer as a message
+		if i > start {
+			c.handler(&Message{
+				Meta:    NewMeta(c.level),
+				Message: string(buffer[start:i]),
+			})
+		}
+
+		h := c.getHeaderFromMatch(m)
+		if !h.multiline {
+			//find next new line or end of line
+			j := i + h.length               //start of text after the header
+			j += c.newLineOrEOF(buffer[j:]) //seek to new line or end of text
+
+			c.handler(&Message{
+				Meta:    NewMeta(h.level),
+				Message: string(buffer[i+h.length : j]),
+			})
+			i = j + 1
+			start = i
+			//TODO: what if the same line output is split !!
+			//I think it's better if the single line message must end with new line, in that case we
+			//need to seek only to new line termination, if not found we save the current state and
+			//wait for the next feedback
+			continue
+		}
+
+		//TODO:
+		//if we are here we must find the \n::: termination string
+	}
+
+	if start < len(buffer) {
+		c.handler(&Message{
+			Meta:    NewMeta(c.level),
+			Message: string(buffer[start:]),
+		})
+	}
+
+	return 0
 }
 
 func (c *consumerImpl) consume() error {
+	buffer := make([]byte, ioBufferSize)
+	offset := 0
 	for {
-		line, err := c.buffer.ReadString('\n')
+		size, err := c.source.Read(buffer[offset:]) //fill what left of the buffer
 		if err == io.EOF {
-			if len(line) != 0 {
-				c.processLine(line)
-			}
 			return nil
-		} else if err != nil {
-			return err
 		}
 
-		c.processLine(line)
+		all := offset + size
+		reminder := c.process(buffer[:all])
+		if reminder != 0 {
+			//if some data remains at the end of the buffer that
+			//wasn't able to be processed. we need to move it at
+			//the head of the buffer
+			copy(buffer, buffer[all-reminder:all])
+			offset = reminder
+		}
 	}
 }
 

--- a/base/pm/systemprocess_test.go
+++ b/base/pm/systemprocess_test.go
@@ -35,7 +35,7 @@ func TestSystemProcess_Run(t *testing.T) {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "hello world", messages[0].Message); !ok {
+	if ok := assert.Equal(t, "hello world\n", messages[0].Message); !ok {
 		t.Error()
 	}
 }
@@ -68,7 +68,7 @@ func TestSystemProcess_RunStderr(t *testing.T) {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "hello world", messages[0].Message); !ok {
+	if ok := assert.Equal(t, "hello world\n", messages[0].Message); !ok {
 		t.Error()
 	}
 

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -223,7 +223,7 @@ class Response:
         # we can terminate quickly by checking if the process is not running and it has no queued output.
         # if not self.running and r.llen(queue) == 0:
         #     return
-
+        count = 0
         while True:
             data = r.blpop(queue, 10)
             if data is None:
@@ -236,15 +236,15 @@ class Response:
             line = message['message']
             meta = message['meta']
             callback(meta >> 16, line, meta & 0xff)
-
+            count += 1
             if meta & 0x6 != 0:
                 break
+        return count
 
     @staticmethod
     def __default(level, line, meta):
         w = sys.stdout if level == 1 else sys.stderr
         w.write(line)
-        w.write('\n')
 
     def get(self, timeout=None):
         """


### PR DESCRIPTION
We totally refactored how we processes outputs. Since all stdout, stderr of all running processes are intercepted by core-0, doing it efficiently will heavenly improve the memory, and cpu consumption of core0.

Before we processed the output of the processes line by line, which means we created a message (with all it's meta data) per line. And we had a message pushed to redis buffers for each line. This wasted a lot of IO time on message copying and processing.

We needed to do it line by line because of the customized messages format that a process can send (the one prefixed  with `\d+:::?` header. which can be a single line or multi-line string.

The new refactor will not create a message for each `normal` output (the one that is not customised) instead it will try to create a single message with as large buffer as possible.

for example an output like this
```
this is a text printed by a process that has cutomize
output that starts the next line
3::some custom message
then we have another one that is multi line
3:::like this one here
which has many lines 
in a single message
:::
and followed by this tail
```

this will only produce 5 messages instead of 6. This doesn't sound much but in an actual scenario where we don't have many intermediate custom message the difference is really effective. For example, i did this
```python
 cl.bash('cat /var/cache/big.txt', stream=True).stream()
```
where `big.txt` is a 6.2MB file this only produced **206** messages instead of the previous **128457** messages. which reduced the time wasted on IO (and memory/cpu consumption of core0) during the streaming process.
