### PR TITLE
Resolve the zdb address when creating an flist

### DIFF
--- a/apps/core0/helper/socat/resolve.go
+++ b/apps/core0/helper/socat/resolve.go
@@ -1,0 +1,118 @@
+package socat
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+//getInterfaceMatch returns the first interface that has the given ip
+//as <name>, <address>, error
+//error return if no match is found
+func getInterfaceMatch(ip string) (name string, address net.IP, err error) {
+	nics, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+	for _, nic := range nics {
+		var addrs []net.Addr
+		addrs, err = nic.Addrs()
+		if err != nil {
+			return
+		}
+
+		for _, addr := range addrs {
+			if addr, ok := addr.(*net.IPNet); ok {
+				if addr.IP.String() == ip {
+					return nic.Name, addr.IP, nil
+				}
+			}
+		}
+	}
+
+	err = fmt.Errorf("no match found")
+	return
+}
+
+//Resolve resolves an address of the form <ip>:<port> to a direct address to the endpoint
+//IF
+// - the ip address is a local address of this machine
+// - port has a forwarding rule
+//ELSE
+// - return address unchanged
+func Resolve(address string) string {
+	src, err := getSource(address)
+	if err != nil {
+		return address
+	}
+
+	if len(src.ip) == 0 {
+		//we have this check here because getSource allows the <port> <ip>:<port> syntax as well
+		return address
+	}
+
+	nic, ip, err := getInterfaceMatch(src.ip)
+	if err != nil {
+		return address
+	}
+
+	lock.Lock()
+	dst, ok := rules[src.port]
+	lock.Unlock()
+
+	if !ok {
+		return address
+	}
+
+	/*
+		the actual source ip can be as follows:
+		  - empty/0.0.0.0
+		  - IP
+		  - IP/MASK (CIDR)
+		  - interface name
+		  - prefix* (partial match of interface name)
+	*/
+	rewritten := fmt.Sprintf("%s:%d", dst.ip, dst.port)
+	if len(dst.source.ip) == 0 || // empty
+		dst.source.ip == "0.0.0.0" || // 0.0.0.0 ip
+		dst.source.ip == nic || // exact nic match
+		dst.source.ip == ip.String() { // exac ip match
+
+		return rewritten
+	} else if _, network, err := net.ParseCIDR(dst.source.ip); err == nil {
+		if network.Contains(ip) {
+			//source ip is in network
+			return rewritten
+		}
+
+	} else if i := strings.Index(dst.source.ip, "*"); i > 0 {
+		if strings.HasPrefix(nic, dst.source.ip[:i]) {
+			return rewritten
+		}
+	}
+
+	return address
+}
+
+//ResolveURL rewrites a url to a direct address to the end point. Return original url
+//if no forwarding rule configured that matches the given address
+//note, the url host part must be an ip, can't use host names
+func ResolveURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw, err
+	}
+	host := u.Host
+	if u.Port() == "" {
+		port, err := net.LookupPort("tcp", u.Scheme)
+		if err != nil {
+			return raw, err
+		}
+		host = fmt.Sprintf("%s:%d", host, port)
+	}
+
+	u.Host = Resolve(host)
+
+	return u.String(), nil
+}

--- a/apps/core0/helper/socat/resolve_test.go
+++ b/apps/core0/helper/socat/resolve_test.go
@@ -1,0 +1,133 @@
+package socat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveInvalidSyntax(t *testing.T) {
+	address := "1234"
+
+	if ok := assert.Equal(t, address, Resolve(address)); !ok {
+		t.Error()
+	}
+
+	address = ":1234"
+	if ok := assert.Equal(t, address, Resolve(address)); !ok {
+		t.Error()
+	}
+}
+
+func TestResolveAny(t *testing.T) {
+	src, _ := getSource("8080")
+	rules = map[int]rule{
+		src.port: rule{
+			source: src,
+			port:   80,
+			ip:     "1.2.3.4",
+		},
+	}
+
+	if ok := assert.Equal(t, "1.2.3.4:80", Resolve("127.0.0.1:8080")); !ok {
+		t.Error()
+	}
+}
+
+func TestResolveNetwork(t *testing.T) {
+	src, _ := getSource("127.0.0.0/8:8080")
+	rules = map[int]rule{
+		src.port: rule{
+			source: src,
+			port:   80,
+			ip:     "1.2.3.4",
+		},
+	}
+
+	if ok := assert.Equal(t, "1.2.3.4:80", Resolve("127.0.0.1:8080")); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "128.0.0.1:8080", Resolve("128.0.0.1:8080")); !ok {
+		t.Error()
+	}
+}
+
+func TestResolveInf(t *testing.T) {
+	src, _ := getSource("lo:8080")
+	rules = map[int]rule{
+		src.port: rule{
+			source: src,
+			port:   80,
+			ip:     "1.2.3.4",
+		},
+	}
+
+	if ok := assert.Equal(t, "1.2.3.4:80", Resolve("127.0.0.1:8080")); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "192.168.1.1:8080", Resolve("192.168.1.1:8080")); !ok {
+		t.Error()
+	}
+}
+
+func TestResolveInfParital(t *testing.T) {
+	src, _ := getSource("l*:8080")
+	rules = map[int]rule{
+		src.port: rule{
+			source: src,
+			port:   80,
+			ip:     "1.2.3.4",
+		},
+	}
+
+	if ok := assert.Equal(t, "1.2.3.4:80", Resolve("127.0.0.1:8080")); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "192.168.1.1:8080", Resolve("192.168.1.1:8080")); !ok {
+		t.Error()
+	}
+}
+
+func TestResolveURL(t *testing.T) {
+	src, _ := getSource(":80")
+	rules = map[int]rule{
+		src.port: rule{
+			source: src,
+			port:   8080,
+			ip:     "1.2.3.4",
+		},
+	}
+
+	url, err := ResolveURL("http://127.0.0.1/")
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "http://1.2.3.4:8080/", url); !ok {
+		t.Error()
+	}
+
+	url, err = ResolveURL("http://127.0.0.1:9000/")
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "http://127.0.0.1:9000/", url); !ok {
+		t.Error()
+	}
+
+	url, err = ResolveURL("http://localhost/")
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "http://localhost:80/", url); !ok {
+		t.Error()
+	}
+}

--- a/apps/core0/helper/socat/resolve_test.go
+++ b/apps/core0/helper/socat/resolve_test.go
@@ -130,4 +130,14 @@ func TestResolveURL(t *testing.T) {
 	if ok := assert.Equal(t, "http://localhost:80/", url); !ok {
 		t.Error()
 	}
+
+	url, err = ResolveURL("zdb://127.0.0.1:80/")
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "zdb://1.2.3.4:8080/", url); !ok {
+		t.Error()
+	}
 }

--- a/apps/core0/subsys/containers/flist.go
+++ b/apps/core0/subsys/containers/flist.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/threefoldtech/0-core/apps/core0/helper/socat"
 	"github.com/threefoldtech/0-core/base/pm"
 	"gopkg.in/yaml.v2"
 )
@@ -90,7 +91,12 @@ func (m *containerManager) flistCreate(cmd *pm.Command) (interface{}, error) {
 	srcPath := containerPath(cont, args.Src)
 
 	// create flist
-	_, err := zflist("--archive", archivePath, "--create", srcPath, "--backend", args.Storage)
+	storage, err := socat.ResolveURL(args.Storage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process storage url: %s", err)
+	}
+
+	_, err = zflist("--archive", archivePath, "-args.Storageargs.Storage-create", srcPath, "--backend", storage)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/core0/subsys/containers/flist.go
+++ b/apps/core0/subsys/containers/flist.go
@@ -91,12 +91,9 @@ func (m *containerManager) flistCreate(cmd *pm.Command) (interface{}, error) {
 	srcPath := containerPath(cont, args.Src)
 
 	// create flist
-	storage, err := socat.ResolveURL(args.Storage)
-	if err != nil {
-		return nil, fmt.Errorf("failed to process storage url: %s", err)
-	}
+	storage := socat.Resolve(args.Storage)
 
-	_, err = zflist("--archive", archivePath, "-args.Storageargs.Storage-create", srcPath, "--backend", storage)
+	_, err := zflist("--archive", archivePath, "--create", srcPath, "--backend", storage)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is to avoid natting issues when using a zdb instance on the local zero-os node

Fixes #28 