### PR TITLE
Avoid dnating when on same network

### DIFF
--- a/apps/core0/helper/socat/resolve.go
+++ b/apps/core0/helper/socat/resolve.go
@@ -35,6 +35,36 @@ func getInterfaceMatch(ip string) (name string, address net.IP, err error) {
 	return
 }
 
+//getRoutingInterface returns the first interface that has the given ip reachable through
+//its network
+//as <name>, <address>, error
+//error return if no match is found
+func getRoutingInterface(ip string) (name string, network *net.IPNet, err error) {
+	_ip := net.ParseIP(ip)
+	nics, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+	for _, nic := range nics {
+		var addrs []net.Addr
+		addrs, err = nic.Addrs()
+		if err != nil {
+			return
+		}
+
+		for _, addr := range addrs {
+			if addr, ok := addr.(*net.IPNet); ok {
+				if addr.Contains(_ip) {
+					return nic.Name, addr, nil
+				}
+			}
+		}
+	}
+
+	err = fmt.Errorf("no match found")
+	return
+}
+
 //Resolve resolves an address of the form <ip>:<port> to a direct address to the endpoint
 //IF
 // - the ip address is a local address of this machine


### PR DESCRIPTION

container 1 with ip 172.18.0.2 has forward for port 9000
container 2 has ip 172.18.0.3 listens on 9000 (no forwards)
container 3 wants to connect to 172.18.0.3 on port 9000 he will always go to container 1