### PR TITLE
Support for dynamic host ips for dnat

### DIFF
--- a/apps/core0/bootstrap/bootstrap.go
+++ b/apps/core0/bootstrap/bootstrap.go
@@ -307,6 +307,10 @@ func (b *Bootstrap) First() {
 		}
 	}
 
+	if err := MonitorIPChangesUpdateSocat(); err != nil {
+		log.Critical("failed to start dnat ip monitoring")
+	}
+
 	//register core extensions
 	b.registerExtensions(settings.Settings.Extension)
 

--- a/apps/core0/bootstrap/bootstrap.go
+++ b/apps/core0/bootstrap/bootstrap.go
@@ -192,7 +192,7 @@ func (b *Bootstrap) screen() {
 
 		for _, link := range links {
 			name := link.Attrs().Name
-			if name == "lo" || !utils.InString([]string{"device", "tun", "tap"}, link.Type()) {
+			if name == "lo" || !utils.InString([]string{"device", "tun", "tap", "openvswitch"}, link.Type()) {
 				continue
 			}
 			if strings.HasPrefix(name, "tun") || strings.HasPrefix(name, "tap") {

--- a/apps/core0/bootstrap/socat.go
+++ b/apps/core0/bootstrap/socat.go
@@ -1,0 +1,100 @@
+package bootstrap
+
+import (
+	"strings"
+
+	"github.com/threefoldtech/0-core/base/nft"
+
+	"github.com/threefoldtech/0-core/base/pm"
+	"github.com/threefoldtech/0-core/base/pm/stream"
+	"github.com/threefoldtech/0-core/base/utils"
+	"github.com/vishvananda/netlink"
+)
+
+func getCurrentIPs() ([]string, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, err
+	}
+
+	var all []string
+	for _, link := range links {
+		name := link.Attrs().Name
+		if name == "lo" || !utils.InString([]string{"device", "tun", "tap"}, link.Type()) {
+			continue
+		}
+		if strings.HasPrefix(name, "tun") || strings.HasPrefix(name, "tap") {
+			continue
+		}
+
+		ips, _ := netlink.AddrList(link, netlink.FAMILY_V4)
+		for _, ip := range ips {
+			all = append(all, ip.IP.String())
+		}
+	}
+
+	return all, nil
+}
+
+type notifyHook struct {
+	pm.NOOPHook
+	Notify func()
+}
+
+func (n *notifyHook) Message(msg *stream.Message) {
+	if n != nil {
+		n.Notify()
+	}
+}
+
+func MonitorIPChangesUpdateSocat() error {
+	var current map[string]struct{}
+
+	notify := func() {
+		log.Debugf("updating dnat host ips")
+
+		ips, err := getCurrentIPs()
+		if err != nil {
+			log.Errorf("failed to get active ips: %s", err)
+			return
+		}
+
+		for _, ip := range ips {
+			if _, ok := current[ip]; ok {
+				//ip already configure
+				delete(current, ip)
+			}
+		}
+
+		for ip := range current {
+			if err := nft.IPv4SetDel(nft.FamilyIP, "nat", "host", ip); err != nil {
+				log.Errorf("failed to delete host ip(%s): %s", ip, err)
+			}
+		}
+
+		current = make(map[string]struct{})
+
+		for _, ip := range ips {
+			current[ip] = struct{}{}
+		}
+
+		if err := nft.IPv4Set(nft.FamilyIP, "nat", "host", ips...); err != nil {
+			log.Errorf("failed to set host ips(%s): %s", strings.Join(ips, ","), err)
+		}
+	}
+
+	_, err := pm.Run(&pm.Command{
+		ID:      "socat.notify",
+		Command: pm.CommandSystem,
+		Arguments: pm.MustArguments(
+			pm.SystemCommandArguments{
+				Name: "ip",
+				Args: []string{"monitor", "address"},
+			},
+		),
+	}, &notifyHook{
+		Notify: notify,
+	})
+
+	return err
+}

--- a/apps/core0/bootstrap/socat.go
+++ b/apps/core0/bootstrap/socat.go
@@ -86,6 +86,9 @@ func MonitorIPChangesUpdateSocat() error {
 	_, err := pm.Run(&pm.Command{
 		ID:      "socat.notify",
 		Command: pm.CommandSystem,
+		Flags: pm.JobFlags{
+			Protected: true,
+		},
 		Arguments: pm.MustArguments(
 			pm.SystemCommandArguments{
 				Name: "ip",

--- a/apps/core0/bootstrap/socat.go
+++ b/apps/core0/bootstrap/socat.go
@@ -20,7 +20,7 @@ func getCurrentIPs() ([]string, error) {
 	var all []string
 	for _, link := range links {
 		name := link.Attrs().Name
-		if name == "lo" || !utils.InString([]string{"device", "tun", "tap"}, link.Type()) {
+		if name == "lo" || !utils.InString([]string{"device", "tun", "tap", "openvswitch"}, link.Type()) {
 			continue
 		}
 		if strings.HasPrefix(name, "tun") || strings.HasPrefix(name, "tap") {

--- a/apps/core0/helper/socat/host.go
+++ b/apps/core0/helper/socat/host.go
@@ -1,0 +1,6 @@
+package socat
+
+//UpdateHostSet update the local nft host set with the current configured ips
+func UpdateHostSet() error {
+	return nil
+}

--- a/apps/core0/helper/socat/socat.go
+++ b/apps/core0/helper/socat/socat.go
@@ -75,11 +75,10 @@ type rule struct {
 	source source
 	port   int
 	ip     string
-	nic    string
 }
 
 func (r rule) Rule() string {
-	return fmt.Sprintf("iif != \"%s\" %s dnat to %s:%d", r.nic, r.source, r.ip, r.port)
+	return fmt.Sprintf("ip daddr @host %s dnat to %s:%d", r.source, r.ip, r.port)
 }
 
 //SetPortForward create a single port forward from host(port), to ip(addr) and dest(port) in this namespace
@@ -88,11 +87,6 @@ func (r rule) Rule() string {
 func SetPortForward(namespace string, ip string, host string, dest int) error {
 	lock.Lock()
 	defer lock.Unlock()
-
-	nic, _, err := getRoutingInterface(ip)
-	if err != nil {
-		return fmt.Errorf("ip is not routable: %s", err)
-	}
 
 	src, err := getSource(host)
 	if err != nil {
@@ -110,12 +104,12 @@ func SetPortForward(namespace string, ip string, host string, dest int) error {
 		source: src,
 		port:   dest,
 		ip:     ip,
-		nic:    nic,
 	}
 
 	set := nft.Nft{
 		"nat": nft.Table{
-			Family: nft.FamilyIP,
+			Family:   nft.FamilyIP,
+			IPv4Sets: []string{"host"},
 			Chains: nft.Chains{
 				"pre": nft.Chain{
 					Rules: []nft.Rule{

--- a/base/nft/apply.go
+++ b/base/nft/apply.go
@@ -3,7 +3,6 @@ package nft
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	logging "github.com/op/go-logging"
 	"github.com/threefoldtech/0-core/base/pm"
@@ -31,7 +30,7 @@ func Apply(nft Nft) error {
 	}
 	defer func() {
 		f.Close()
-		os.RemoveAll(f.Name())
+		//os.RemoveAll(f.Name())
 	}()
 
 	if _, err := f.Write(data); err != nil {

--- a/base/nft/apply.go
+++ b/base/nft/apply.go
@@ -3,6 +3,7 @@ package nft
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	logging "github.com/op/go-logging"
 	"github.com/threefoldtech/0-core/base/pm"
@@ -30,7 +31,7 @@ func Apply(nft Nft) error {
 	}
 	defer func() {
 		f.Close()
-		//os.RemoveAll(f.Name())
+		os.RemoveAll(f.Name())
 	}()
 
 	if _, err := f.Write(data); err != nil {

--- a/base/nft/nft.go
+++ b/base/nft/nft.go
@@ -46,15 +46,21 @@ func (n Nft) MarshalText() ([]byte, error) {
 type Chains map[string]Chain
 
 type Table struct {
-	Family Family
-	Chains Chains
+	Family   Family
+	Chains   Chains
+	IPv4Sets []string
 }
 
 func (t *Table) marshal(name string, buf *bytes.Buffer) error {
 	if t.Family == Family("") {
 		return fmt.Errorf("family is required")
 	}
+
 	buf.WriteString(fmt.Sprintf("table %s %s {\n", t.Family, name))
+	for _, ipv4set := range t.IPv4Sets {
+		buf.WriteString(fmt.Sprintf("set %s { type ipv4_addr; }\n", ipv4set))
+	}
+
 	for name, chain := range t.Chains {
 		if name == "" {
 			return fmt.Errorf("empty chain name")

--- a/base/nft/parse_test.go
+++ b/base/nft/parse_test.go
@@ -8,6 +8,10 @@ import (
 
 const (
 	sample = `table ip nat {
+	set host {
+		type ipv4_addr;
+		elements = { 10.20.1.1 }
+	}
 	chain pre {
 		type nat hook prerouting priority 0; policy accept;
 		iif "core0" mark set 0x00000001 # handle 3

--- a/base/nft/parser.go
+++ b/base/nft/parser.go
@@ -21,6 +21,10 @@ func Get() (Nft, error) {
 }
 
 func Parse(config string) (Nft, error) {
+	//HACK: remove the set definition from the nft ruleset to avoid fixing this messy parser
+	//TODO: nft can export ruleset as json, we can use that instead, but it seems not to be enabled
+	//on our build
+	config = setCleanup(config)
 
 	level := NFT
 
@@ -97,7 +101,13 @@ var (
 	chainRegex     = regexp.MustCompile("chain ([a-z]+)")
 	chainPropRegex = regexp.MustCompile("type ([a-z]+) hook ([a-z]+) priority ([0-9]+); policy ([a-z]+);")
 	ruleRegex      = regexp.MustCompile("\\s*(.+) # handle ([0-9]+)")
+
+	setCleanupRegex = regexp.MustCompile(`(?smU:set [^\s]+ {.+^\s+}$)`)
 )
+
+func setCleanup(cfg string) string {
+	return setCleanupRegex.ReplaceAllString(cfg, "")
+}
 
 func parseTable(line []byte) ([]byte, *Table) {
 	match := tableRegex.FindSubmatch(line)

--- a/base/nft/set.go
+++ b/base/nft/set.go
@@ -1,0 +1,45 @@
+package nft
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/threefoldtech/0-core/base/pm"
+)
+
+//IPv4Set creates/updates element set of type ipv4_addr
+func IPv4Set(family Family, table string, name string, ips ...string) error {
+	//nft add set ip nat host { type ipv4_addr\; }
+	//nft add element ip nat host { 172^C9.0.1, 172.18.0.1 }
+
+	_, err := pm.System("nft", "add", "set", string(family), table, name, "{", "type", "ipv4_addr;", "}")
+	if err != nil {
+		return err
+	}
+
+	if len(ips) == 0 {
+		return nil
+	}
+
+	m := strings.Join(ips, ", ")
+	_, err = pm.System("nft", "add", "element", string(family), table, name, "{", m, "}")
+
+	return err
+}
+
+//IPv4SetDel delete ips from a ipv4_addr set
+func IPv4SetDel(family Family, table, name string, ips ...string) error {
+	if len(ips) == 0 {
+		return nil
+	}
+
+	m := strings.Join(ips, ", ")
+	_, err := pm.System("nft", "delete", "element", string(family), table, name, "{", m, "}")
+
+	return err
+}
+
+//IPv4SetGet gets the current ipv4 set
+func IPv4SetGet(family Family, table, name string) ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
The idea is simple
- I found that nft support something called sets, which is basically a configurable list of elements (ipv4 in our case)
- dnat rule now can use this set like `daddr @host dport 9900 dnat to <dest-ip>:<dest-port>`  where `host` is the set name
- on booting the system, i configure the `host` set with an empty set.
- I start a background process for `ip monitor address` which blocks forever and writes on stdout when some changes happen
- I create a hook for the process so once something is written to stdout, i rebuild a list of host ips, and update nft host set.

This means basically the host set in nft will get update if new ips are added (zerotier join for example) or removed, statically or via dhcp, etc...
  