### PR TITLE
Reserve ports

### DIFF
--- a/apps/core0/helper/socat/api.go
+++ b/apps/core0/helper/socat/api.go
@@ -1,0 +1,54 @@
+package socat
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/threefoldtech/0-core/base/pm"
+)
+
+const (
+	cmdSocatList   = "socat.list"
+	cmdSocalReseve = "socat.reserve"
+)
+
+func init() {
+	pm.RegisterBuiltIn(cmdSocatList, socat.list)
+	pm.RegisterBuiltIn(cmdSocalReseve, socat.reserve)
+}
+
+func (s *socatApi) list(cmd *pm.Command) (interface{}, error) {
+	s.rm.Lock()
+	defer s.rm.Unlock()
+
+	type simpleRule struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+
+	m := make(map[int]simpleRule)
+	for s, r := range s.rules {
+		m[s] = simpleRule{
+			From: fmt.Sprintf("%s:%d", r.source.ip, r.source.port),
+			To:   fmt.Sprintf("%s:%d", r.ip, r.port),
+		}
+	}
+
+	return m, nil
+}
+
+func (s *socatApi) reserve(cmd *pm.Command) (interface{}, error) {
+	var query struct {
+		Numer int `json:"number"`
+	}
+
+	if err := json.Unmarshal(*cmd.Arguments, &query); err != nil {
+		return nil, pm.BadRequestError(err)
+	}
+
+	if query.Numer == 0 {
+		return nil, pm.BadRequestError("reseve number cannot be zero")
+	}
+
+	return s.Reserve(query.Numer)
+}

--- a/apps/core0/helper/socat/resolve.go
+++ b/apps/core0/helper/socat/resolve.go
@@ -71,7 +71,7 @@ func getRoutingInterface(ip string) (name string, network *net.IPNet, err error)
 // - port has a forwarding rule
 //ELSE
 // - return address unchanged
-func Resolve(address string) string {
+func (s *socatApi) Resolve(address string) string {
 	src, err := getSource(address)
 	if err != nil {
 		return address
@@ -87,9 +87,9 @@ func Resolve(address string) string {
 		return address
 	}
 
-	lock.Lock()
-	dst, ok := rules[src.port]
-	lock.Unlock()
+	s.rm.Lock()
+	dst, ok := s.rules[src.port]
+	s.rm.Unlock()
 
 	if !ok {
 		return address
@@ -128,7 +128,7 @@ func Resolve(address string) string {
 //ResolveURL rewrites a url to a direct address to the end point. Return original url
 //if no forwarding rule configured that matches the given address
 //note, the url host part must be an ip, can't use host names
-func ResolveURL(raw string) (string, error) {
+func (s *socatApi) ResolveURL(raw string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return raw, err
@@ -142,7 +142,7 @@ func ResolveURL(raw string) (string, error) {
 		host = fmt.Sprintf("%s:%d", host, port)
 	}
 
-	u.Host = Resolve(host)
+	u.Host = s.Resolve(host)
 
 	return u.String(), nil
 }

--- a/apps/core0/helper/socat/resolve_test.go
+++ b/apps/core0/helper/socat/resolve_test.go
@@ -21,7 +21,7 @@ func TestResolveInvalidSyntax(t *testing.T) {
 
 func TestResolveAny(t *testing.T) {
 	src, _ := getSource("8080")
-	rules = map[int]rule{
+	socat.rules = map[int]rule{
 		src.port: rule{
 			source: src,
 			port:   80,
@@ -36,7 +36,7 @@ func TestResolveAny(t *testing.T) {
 
 func TestResolveNetwork(t *testing.T) {
 	src, _ := getSource("127.0.0.0/8:8080")
-	rules = map[int]rule{
+	socat.rules = map[int]rule{
 		src.port: rule{
 			source: src,
 			port:   80,
@@ -55,7 +55,7 @@ func TestResolveNetwork(t *testing.T) {
 
 func TestResolveInf(t *testing.T) {
 	src, _ := getSource("lo:8080")
-	rules = map[int]rule{
+	socat.rules = map[int]rule{
 		src.port: rule{
 			source: src,
 			port:   80,
@@ -74,7 +74,7 @@ func TestResolveInf(t *testing.T) {
 
 func TestResolveInfParital(t *testing.T) {
 	src, _ := getSource("l*:8080")
-	rules = map[int]rule{
+	socat.rules = map[int]rule{
 		src.port: rule{
 			source: src,
 			port:   80,
@@ -93,7 +93,7 @@ func TestResolveInfParital(t *testing.T) {
 
 func TestResolveURL(t *testing.T) {
 	src, _ := getSource(":80")
-	rules = map[int]rule{
+	socat.rules = map[int]rule{
 		src.port: rule{
 			source: src,
 			port:   8080,

--- a/apps/core0/helper/socat/singlton.go
+++ b/apps/core0/helper/socat/singlton.go
@@ -1,0 +1,35 @@
+package socat
+
+//SetPortForward create a single port forward from host(port), to ip(addr) and dest(port) in this namespace
+//The namespace is used to group port forward rules so they all can get terminated
+//with one call later.
+func SetPortForward(namespace string, ip string, host string, dest int) error {
+	return socat.SetPortForward(namespace, ip, host, dest)
+}
+
+//RemovePortForward removes a single port forward
+func RemovePortForward(namespace string, host string, dest int) error {
+	return socat.RemovePortForward(namespace, host, dest)
+}
+
+//RemoveAll remove all port forwrards that were created in this namespace.
+func RemoveAll(namespace string) error {
+	return socat.RemoveAll(namespace)
+}
+
+//Resolve resolves an address of the form <ip>:<port> to a direct address to the endpoint
+//IF
+// - the ip address is a local address of this machine
+// - port has a forwarding rule
+//ELSE
+// - return address unchanged
+func Resolve(address string) string {
+	return socat.Resolve(address)
+}
+
+//ResolveURL rewrites a url to a direct address to the end point. Return original url
+//if no forwarding rule configured that matches the given address
+//note, the url host part must be an ip, can't use host names
+func ResolveURL(raw string) (string, error) {
+	return socat.ResolveURL(raw)
+}

--- a/base/pm/pm.go
+++ b/base/pm/pm.go
@@ -1,6 +1,7 @@
 package pm
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -528,4 +529,28 @@ func System(bin string, args ...string) (*JobResult, error) {
 	job.Streams[1] = output.Stderr.String()
 
 	return job, nil
+}
+
+//Internal run builtin command by name
+func Internal(cmd string, args M, out interface{}) error {
+	runner, err := Run(&Command{
+		ID:        uuid.New(),
+		Command:   cmd,
+		Arguments: MustArguments(args),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	job := runner.Wait()
+	if job.State != StateSuccess {
+		return Error(job.Code, fmt.Errorf("(%s): %v", job.State, job.Streams))
+	}
+
+	if job.Level != stream.LevelResultJSON {
+		return fmt.Errorf("invalid return format expecting json, got %d", job.Level)
+	}
+
+	return json.Unmarshal([]byte(job.Data), out)
 }

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -3124,6 +3124,41 @@ class ZFSManager():
             'cache': ['local'],
         }
 
+class SocatManager():
+    def __init__(self, client):
+        self._client = client
+
+    def list(self):
+        """
+        List port forwards
+        """
+        return self._client.json('socat.list', {})
+
+    def reserve(self, number=1):
+        """
+        Resever the given number of ports, and return the reserved ports
+
+        :note: A reserved port is not granteed to be used by u only, it means
+        other call to reserve for the next 2 minutes is granteed to not return
+        this port.
+
+        So to make reservation works properly, u first do `reserve` then use
+        the returned port for your forwards (u have 2 minutes). Once the port
+        forward is done, the port is never returned by reseve. If no port forward
+        was created using this port, the port is returned to the free pool
+
+        :note: port forward creation (using container, or kvm) doesn't check if the
+        port is reserved at all.
+
+        :param number: number of ports to reserve
+        """
+
+        args = {
+            'number': number,
+        }
+
+        return self._client.json('socat.reserve', args)
+
 
 class Client(BaseClient):
     _raw_chk = typchk.Checker({
@@ -3163,6 +3198,7 @@ class Client(BaseClient):
         self._rtinfo = RTInfoManager(self)
         self._cgroup = CGroupManager(self)
         self._zfs = ZFSManager(self)
+        self._socat = SocatManager(self)
 
 
         if testConnectionAttempts:
@@ -3174,6 +3210,10 @@ class Client(BaseClient):
                 else:
                     return
             raise ConnectionError("Could not connect to remote host %s" % host)
+
+    @property
+    def socat(self):
+        return self._socat
 
     @property
     def zfs(self):


### PR DESCRIPTION
Reserve a port for port-forwards 

The reservation works as follows (atomically)
- You ask to reserve an `x` amount of ports
- The system detects the local listening ports, plus the ports used for other port forwards, and finally the reserved ports
- The system tries to find the first free port in the valid ports range.
- Once the number of ports are fulfilled, the reserved ports are update with this set of ports.
- The list of newly reserved ports, are returned.

> The reserved ports times out if not used by the port forward rule (happens implicitly by container.create, and kvm.create) the timeout is around 2 minutes.

> You still can create port forwards that doesn't allocate a reserved port, reservation only helps clients to synchronize and not to conflict on port forward rules.

## Client reservation process
- Call reserve ports with number of required ports
- Create your container, or vm using the returned ports only

Fixes #51 