### PR TITLE
Rewrite nft parsing using json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - language: go
       sudo: true
       dist: trusty
-      go: 1.8
+      go: "1.10.x"
       before_install:
         - sudo apt-get -qq update
         - sudo apt-get install -y libvirt-dev libcap-dev

--- a/apps/core0/helper/filesystem/filesystem.go
+++ b/apps/core0/helper/filesystem/filesystem.go
@@ -224,6 +224,7 @@ func MountFList(namespace, storage, src string, target string, hooks ...pm.Runne
 	}
 
 	var err error
+	var j pm.Job
 	var o sync.Once
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -237,14 +238,18 @@ func MountFList(namespace, storage, src string, target string, hooks ...pm.Runne
 		Action: func(s bool) {
 			o.Do(func() {
 				if !s {
-					err = fmt.Errorf("abnormal exit of filesystem mount at '%s'", target)
+					result := j.Wait()
+					err = fmt.Errorf("abnormal exit of filesystem mount at '%s': %s", target, result.Streams)
 				}
 				wg.Done()
 			})
 		},
 	})
 
-	pm.Run(cmd, hooks...)
+	j, err = pm.Run(cmd, hooks...)
+	if err != nil {
+		return err
+	}
 
 	//wait for either of the hooks (ready or exit)
 	wg.Wait()

--- a/apps/core0/helper/socat/socat.go
+++ b/apps/core0/helper/socat/socat.go
@@ -183,8 +183,10 @@ func (s *socatAPI) SetPortForward(namespace string, ip string, host string, dest
 
 	set := nft.Nft{
 		"nat": nft.Table{
-			Family:   nft.FamilyIP,
-			IPv4Sets: []string{"host"},
+			Family: nft.FamilyIP,
+			Sets: nft.Sets{
+				"host": nft.Set{},
+			},
 			Chains: nft.Chains{
 				"pre": nft.Chain{
 					Rules: rs,

--- a/apps/core0/subsys/containers/network.go
+++ b/apps/core0/subsys/containers/network.go
@@ -801,10 +801,16 @@ func (c *container) destroyNetwork() {
 			fallthrough
 		case "vlan":
 			ovs := c.mgr.GetOneWithTags(OVSTag)
-			c.unBridge(idx, network, ovs)
+			if err := c.unBridge(idx, network, ovs); err != nil {
+				log.Errorf("failed to destroy network: %v", err)
+			}
 		case "default":
-			c.unBridge(idx, network, nil)
-			socat.RemoveAll(c.forwardId())
+			if err := c.unBridge(idx, network, nil); err != nil {
+				log.Errorf("failed to destroy network: %v", err)
+			}
+			if err := socat.RemoveAll(c.forwardId()); err != nil {
+				log.Errorf("failed to destroy port forwards: %v", err)
+			}
 		}
 	}
 

--- a/base/nft/nft_test.go
+++ b/base/nft/nft_test.go
@@ -39,49 +39,7 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestFindRules(t *testing.T) {
-	config := `table ip nat {
-	chain pre {
-		type nat hook prerouting priority 0; policy accept;
-		iif "core0" mark set 0x00000001 # handle 3
-		iif "kvm0" mark set 0x00000001 # handle 6
-		tcp dport 6600 dnat to 172.18.0.2:6600 # handle 9
-		tcp dport 2200 dnat to 172.19.0.2:22 # handle 10
-	}
-
-	chain post {
-		type nat hook postrouting priority 0; policy accept;
-		ip saddr 172.18.0.0/16 masquerade # handle 5
-		ip saddr 172.19.0.0/16 masquerade # handle 7
-	}
-}
-table inet filter {
-	chain input {
-		type filter hook input priority 0; policy drop;
-		ct state { related, established} accept # handle 4
-		iifname "lo" accept # handle 5
-		iifname "vxbackend" accept # handle 6
-		ip protocol 1 accept # handle 7
-		iif "core0" udp dport { 68, 53, 67} accept # handle 8
-		tcp dport 6600 accept # handle 11
-		tcp dport 6379 accept # handle 12
-		tcp dport 22 accept # handle 13
-		iif "kvm0" udp dport { 67, 53, 68} accept # handle 16
-		tcp dport 5900 accept # handle 17
-	}
-
-	chain forward {
-		type filter hook forward priority 0; policy accept;
-		iif "core0" oif "core0" mark set 0x00000002 # handle 9
-		oif "core0" mark 0x00000001 drop # handle 10
-		iif "kvm0" oif "kvm0" mark set 0x00000002 # handle 14
-		oif "kvm0" mark 0x00000001 drop # handle 15
-	}
-
-	chain output {
-		type filter hook output priority 0; policy accept;
-	}
-}
-	`
+	config := `{"nftables": [{"table": {"family": "ip", "name": "nat", "handle": 0}}, {"set": {"family": "ip", "elem": ["10.20.1.1", "172.18.0.1", "172.19.0.1"], "name": "host", "table": "nat", "handle": 0, "type": "ipv4_addr"}}, {"chain": {"hook": "prerouting", "family": "ip", "table": "nat", "prio": 0, "name": "pre", "type": "nat", "handle": 1, "policy": "accept"}}, {"rule": {"chain": "pre", "family": "ip", "table": "nat", "handle": 7, "expr": [{"match": {"left": {"payload": {"field": "daddr", "name": "ip"}}, "right": "@host"}}, {"match": {"left": {"meta": "iifname"}, "right": "eth0"}}, {"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 8000}}, {"dnat": {"addr": "172.18.0.2", "port": 7999}}]}}, {"chain": {"hook": "postrouting", "family": "ip", "table": "nat", "prio": 0, "name": "post", "type": "nat", "handle": 2, "policy": "accept"}}, {"rule": {"chain": "post", "family": "ip", "table": "nat", "handle": 4, "expr": [{"match": {"left": {"payload": {"field": "saddr", "name": "ip"}}, "right": {"prefix": {"addr": "172.18.0.0", "len": 16}}}}, {"masquerade": null}]}}, {"rule": {"chain": "post", "family": "ip", "table": "nat", "handle": 5, "expr": [{"match": {"left": {"payload": {"field": "saddr", "name": "ip"}}, "right": {"prefix": {"addr": "172.19.0.0", "len": 16}}}}, {"masquerade": null}]}}, {"table": {"family": "inet", "name": "filter", "handle": 0}}, {"chain": {"hook": "prerouting", "family": "inet", "table": "filter", "prio": 0, "name": "pre", "type": "filter", "handle": 1, "policy": "accept"}}, {"chain": {"hook": "forward", "family": "inet", "table": "filter", "prio": 0, "name": "forward", "type": "filter", "handle": 2, "policy": "accept"}}, {"chain": {"hook": "output", "family": "inet", "table": "filter", "prio": 0, "name": "output", "type": "filter", "handle": 3, "policy": "accept"}}, {"chain": {"hook": "input", "family": "inet", "table": "filter", "prio": 0, "name": "input", "type": "filter", "handle": 4, "policy": "drop"}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 5, "expr": [{"match": {"left": {"ct": {"key": "state"}}, "right": {"set": ["established", "related"]}}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 6, "expr": [{"match": {"left": {"meta": "iifname"}, "right": "lo"}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 7, "expr": [{"match": {"left": {"meta": "iifname"}, "right": "vxbackend"}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 8, "expr": [{"match": {"left": {"payload": {"field": "protocol", "name": "ip"}}, "right": 1}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 9, "expr": [{"match": {"left": {"meta": "iif"}, "right": "core0"}}, {"match": {"left": {"payload": {"field": "dport", "name": "udp"}}, "right": {"set": [53, 67, 68]}}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 10, "expr": [{"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 22}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 11, "expr": [{"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 6379}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 12, "expr": [{"match": {"left": {"meta": "iif"}, "right": "kvm0"}}, {"match": {"left": {"payload": {"field": "dport", "name": "udp"}}, "right": {"set": [53, 67, 68]}}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 13, "expr": [{"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 5900}}, {"accept": null}]}}]}`
 
 	ruleset, err := Parse(config)
 
@@ -95,7 +53,7 @@ table inet filter {
 			Chains: Chains{
 				"pre": Chain{
 					Rules: []Rule{
-						{Body: "tcp dport 2200 dnat to 172.19.0.2:22"},
+						{Body: "ip daddr @host iifname \"eth0\" tcp dport 8000 dnat to 172.18.0.2:7999"},
 					},
 				},
 			},
@@ -117,11 +75,11 @@ table inet filter {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, 10, sub["nat"].Chains["pre"].Rules[0].Handle); !ok {
+	if ok := assert.Equal(t, 7, sub["nat"].Chains["pre"].Rules[0].Handle); !ok {
 		t.Error()
 	}
 
-	if ok := assert.Equal(t, 17, sub["filter"].Chains["input"].Rules[0].Handle); !ok {
+	if ok := assert.Equal(t, 13, sub["filter"].Chains["input"].Rules[0].Handle); !ok {
 		t.Error()
 	}
 }

--- a/base/nft/parse_test.go
+++ b/base/nft/parse_test.go
@@ -7,107 +7,96 @@ import (
 )
 
 const (
-	sample = `table ip nat {
-	set host {
-		type ipv4_addr;
-		elements = { 10.20.1.1 }
-	}
-	chain pre {
-		type nat hook prerouting priority 0; policy accept;
-		iif "core0" mark set 0x00000001 # handle 3
-		iif "kvm0" mark set 0x00000001 # handle 6
-		tcp dport 6600 dnat to 172.18.0.2:6600 # handle 9
-		tcp dport 8000 dnat to 172.18.0.3:80 # handle 10
-	}
-
-	chain post {
-		type nat hook postrouting priority 0; policy accept;
-		ip saddr 172.18.0.0/16 masquerade # handle 5
-		ip saddr 172.19.0.0/16 masquerade # handle 7
-	}
-}
-table inet filter {
-	chain input {
-		type filter hook input priority 0; policy drop;
-		ct state { established, related} accept # handle 4
-		iifname "lo" accept # handle 5
-		iifname "vxbackend" accept # handle 6
-		ip protocol 1 accept # handle 7
-		iif "core0" udp dport { 67, 68, 53} accept # handle 8
-		tcp dport 6600 accept # handle 11
-		tcp dport 22 accept # handle 12
-		tcp dport 6379 accept # handle 13
-		iif "kvm0" udp dport { 68, 53, 67} accept # handle 14
-	}
-
-	chain forward {
-		type filter hook forward priority 0; policy accept;
-		iif "core0" oif "core0" mark set 0x00000002 # handle 9
-		oif "core0" mark 0x00000001 drop # handle 10
-		iif "kvm0" oif "kvm0" mark set 0x00000002 # handle 15
-		oif "kvm0" mark 0x00000001 drop # handle 16
-	}
-
-	chain output {
-		type filter hook output priority 0; policy accept;
-	}
-}
-	`
+	input = `{"nftables": [{"table": {"family": "ip", "name": "nat", "handle": 0}}, {"set": {"family": "ip", "elem": ["10.20.1.1", "172.18.0.1", "172.19.0.1"], "name": "host", "table": "nat", "handle": 0, "type": "ipv4_addr"}}, {"chain": {"hook": "prerouting", "family": "ip", "table": "nat", "prio": 0, "name": "pre", "type": "nat", "handle": 1, "policy": "accept"}}, {"rule": {"chain": "pre", "family": "ip", "table": "nat", "handle": 7, "expr": [{"match": {"left": {"payload": {"field": "daddr", "name": "ip"}}, "right": "@host"}}, {"match": {"left": {"meta": "iifname"}, "right": "eth0"}}, {"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 8000}}, {"dnat": {"addr": "172.18.0.2", "port": 7999}}]}}, {"chain": {"hook": "postrouting", "family": "ip", "table": "nat", "prio": 0, "name": "post", "type": "nat", "handle": 2, "policy": "accept"}}, {"rule": {"chain": "post", "family": "ip", "table": "nat", "handle": 4, "expr": [{"match": {"left": {"payload": {"field": "saddr", "name": "ip"}}, "right": {"prefix": {"addr": "172.18.0.0", "len": 16}}}}, {"masquerade": null}]}}, {"rule": {"chain": "post", "family": "ip", "table": "nat", "handle": 5, "expr": [{"match": {"left": {"payload": {"field": "saddr", "name": "ip"}}, "right": {"prefix": {"addr": "172.19.0.0", "len": 16}}}}, {"masquerade": null}]}}, {"table": {"family": "inet", "name": "filter", "handle": 0}}, {"chain": {"hook": "prerouting", "family": "inet", "table": "filter", "prio": 0, "name": "pre", "type": "filter", "handle": 1, "policy": "accept"}}, {"chain": {"hook": "forward", "family": "inet", "table": "filter", "prio": 0, "name": "forward", "type": "filter", "handle": 2, "policy": "accept"}}, {"chain": {"hook": "output", "family": "inet", "table": "filter", "prio": 0, "name": "output", "type": "filter", "handle": 3, "policy": "accept"}}, {"chain": {"hook": "input", "family": "inet", "table": "filter", "prio": 0, "name": "input", "type": "filter", "handle": 4, "policy": "drop"}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 5, "expr": [{"match": {"left": {"ct": {"key": "state"}}, "right": {"set": ["established", "related"]}}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 6, "expr": [{"match": {"left": {"meta": "iifname"}, "right": "lo"}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 7, "expr": [{"match": {"left": {"meta": "iifname"}, "right": "vxbackend"}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 8, "expr": [{"match": {"left": {"payload": {"field": "protocol", "name": "ip"}}, "right": 1}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 9, "expr": [{"match": {"left": {"meta": "iif"}, "right": "core0"}}, {"match": {"left": {"payload": {"field": "dport", "name": "udp"}}, "right": {"set": [53, 67, 68]}}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 10, "expr": [{"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 22}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 11, "expr": [{"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 6379}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 12, "expr": [{"match": {"left": {"meta": "iif"}, "right": "kvm0"}}, {"match": {"left": {"payload": {"field": "dport", "name": "udp"}}, "right": {"set": [53, 67, 68]}}}, {"accept": null}]}}, {"rule": {"chain": "input", "family": "inet", "table": "filter", "handle": 13, "expr": [{"match": {"left": {"payload": {"field": "dport", "name": "tcp"}}, "right": 5900}}, {"accept": null}]}}]}`
 )
 
-func TestNFTParse(t *testing.T) {
-	nft, err := Parse(sample)
+//Human readable
+/*
+table ip nat {
+        set host {
+                type ipv4_addr
+                elements = { 10.20.1.1, 172.18.0.1,
+                             172.19.0.1 }
+        }
+
+        chain pre {
+                type nat hook prerouting priority 0; policy accept;
+                ip daddr @host iifname "eth0" tcp dport 8000 dnat to 172.18.0.2:7999
+        }
+
+        chain post {
+                type nat hook postrouting priority 0; policy accept;
+                ip saddr 172.18.0.0/16 masquerade
+                ip saddr 172.19.0.0/16 masquerade
+        }
+}
+table inet filter {
+        chain pre {
+                type filter hook prerouting priority 0; policy accept;
+        }
+
+        chain forward {
+                type filter hook forward priority 0; policy accept;
+        }
+
+        chain output {
+                type filter hook output priority 0; policy accept;
+        }
+
+        chain input {
+                type filter hook input priority 0; policy drop;
+                ct state { established, related } accept
+                iifname "lo" accept
+                iifname "vxbackend" accept
+                ip protocol 1 accept
+                iif "core0" udp dport { 53, 67, 68 } accept
+                tcp dport 22 accept
+                tcp dport 6379 accept
+                iif "kvm0" udp dport { 53, 67, 68 } accept
+                tcp dport 5900 accept
+        }
+}
+*/
+
+func TestParse(t *testing.T) {
+	nft, err := Parse(input)
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
 
 	if ok := assert.NoError(t, err); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Len(t, nft, 2); !ok { // 2 tables
-		t.Error()
-	}
-
-	filter := nft["filter"]
-
-	if ok := assert.Equal(t, FamilyINET, filter.Family); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Len(t, filter.Chains, 3); !ok { // 3 chains
-		t.Error()
-	}
-
-	input := filter.Chains["input"]
-
-	if ok := assert.Len(t, input.Rules, 9); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, Type("filter"), input.Type); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, "input", input.Hook); !ok {
-		t.Error()
-	}
-
-	if ok := assert.Equal(t, "drop", input.Policy); !ok {
-		t.Error()
-	}
-
-	rule := input.Rules[0]
-	if ok := assert.Equal(t, 4, rule.Handle); !ok {
+	if ok := assert.Len(t, nft, 2); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "ct state { established, related} accept", rule.Body); !ok {
-		t.Fatal()
+	filter, ok := nft["filter"]
+	if !ok {
+		t.Fatal("filter table not found")
 	}
-
-	if ok := assert.Equal(t, 9, nft["nat"].Chains["pre"].Rules[2].Handle); !ok {
+	nat, ok := nft["nat"]
+	if !ok {
+		t.Fatal("nat table not found")
+	}
+	if ok := assert.Len(t, filter.Chains, 4); !ok {
 		t.Error()
 	}
 
-	if ok := assert.Equal(t, "tcp dport 6600 dnat to 172.18.0.2:6600", nft["nat"].Chains["pre"].Rules[2].Body); !ok {
+	if ok := assert.Len(t, nat.Chains, 2); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "ip daddr @host iifname \"eth0\" tcp dport 8000 dnat to 172.18.0.2:7999", nat.Chains["pre"].Rules[0].Body); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "iif \"kvm0\" udp dport { 53, 67, 68 } accept", filter.Chains["input"].Rules[7].Body); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, "tcp dport 5900 accept", filter.Chains["input"].Rules[8].Body); !ok {
 		t.Error()
 	}
 }


### PR DESCRIPTION

- Rewrite the full nft parser to use json output of nft
- Add more logs

This is done this way to avoid some inconsistency of the human readable nft output that sometimes causes parsing issues.

This might have cause some port forward deletion to fail because zos can't find the rule handle anymore.

Probably fixes #77 

The new parser has been covered by unittests, but we need to test actual nodes that were affected by this bug.