### PR TITLE
disk is standby, nic.info has now bool flag for 'carrier' and 'operstate', and kernel parameters for noautonic

### DIFF
--- a/apps/core0/bootstrap/bootstrap.go
+++ b/apps/core0/bootstrap/bootstrap.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/op/go-logging"
-	"github.com/patrickmn/go-cache"
+	logging "github.com/op/go-logging"
+	cache "github.com/patrickmn/go-cache"
 	"github.com/threefoldtech/0-core/apps/core0/bootstrap/network"
 	"github.com/threefoldtech/0-core/apps/core0/options"
 	"github.com/threefoldtech/0-core/apps/core0/screen"
@@ -137,8 +137,15 @@ func (b *Bootstrap) setupNetworking() error {
 		return fmt.Errorf("failed to get network interfaces: %s", err)
 	}
 
+	ignore, _ := options.Options.Kernel.Get("noautonic")
+
 	//apply the interfaces settings as configured.
 	for _, inf := range interfaces {
+		if utils.InString(ignore, inf.Name()) {
+			log.Infof("skipping auto config for interface '%s'", inf.Name())
+			continue
+		}
+
 		log.Infof("Setting up interface '%s'", inf.Name())
 
 		inf.Clear()

--- a/apps/core0/bootstrap/bootstrap.go
+++ b/apps/core0/bootstrap/bootstrap.go
@@ -153,6 +153,7 @@ func (b *Bootstrap) setupNetworking() error {
 		go func(inf network.Interface) {
 			if err := inf.Configure(); err != nil {
 				log.Errorf("%s", err)
+				inf.SetUP(false)
 			}
 		}(inf)
 	}

--- a/apps/core0/bootstrap/network/dhcp.go
+++ b/apps/core0/bootstrap/network/dhcp.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"github.com/vishvananda/netlink"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -40,7 +39,7 @@ func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
 	// if err := d.isPlugged(inf); err != nil {
 	// 	return err
 	// }
-	
+
 	hostname, _ := os.Hostname()
 	hostid := fmt.Sprintf("hostname:zero-os-%s", hostname)
 
@@ -64,14 +63,7 @@ func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
 	}
 
 	if _, err := pm.Run(cmd); err != nil {
-		// to counter eventual problems with switches and their arp table,
-		// also disable (ip l set $iface down)
-		link, err := netlink.LinkByName(inf)
-		if err != nil {
-			return err
-		}
-
-		if err := netlink.LinkSetDown(link); err != nil { return err }
+		return err
 	}
 
 	return nil

--- a/apps/core0/bootstrap/network/dhcp.go
+++ b/apps/core0/bootstrap/network/dhcp.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/vishvananda/netlink"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -63,7 +64,14 @@ func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
 	}
 
 	if _, err := pm.Run(cmd); err != nil {
-		return err
+		// to counter eventual problems with switches and their arp table,
+		// also disable (ip l set $iface down)
+		link, err := netlink.LinkByName(inf)
+		if err != nil {
+			return err
+		}
+
+		if err := netlink.LinkSetDown(link); err != nil { return err }
 	}
 
 	return nil

--- a/apps/core0/options/options.go
+++ b/apps/core0/options/options.go
@@ -3,8 +3,9 @@ package options
 import (
 	"flag"
 	"fmt"
-	"github.com/threefoldtech/0-core/base/utils"
 	"os"
+
+	"github.com/threefoldtech/0-core/base/utils"
 )
 
 type AppOptions struct {

--- a/base/builtin/info.go
+++ b/base/builtin/info.go
@@ -17,7 +17,6 @@ import (
 	"github.com/shirou/gopsutil/net"
 	base "github.com/threefoldtech/0-core/base"
 	"github.com/threefoldtech/0-core/base/pm"
-	"gopkg.in/bufio.v1"
 )
 
 const (
@@ -65,7 +64,9 @@ func getMemInfo(cmd *pm.Command) (interface{}, error) {
 
 type NicInfo struct {
 	net.InterfaceStat
-	Speed int64 `json:"speed"`
+	Speed     int64 `json:"speed"`
+	Carrier   int64 `json:"carrier"`
+	OperState int64 `json:"operstate"`
 }
 
 func getNicInfo(cmd *pm.Command) (interface{}, error) {
@@ -81,13 +82,17 @@ func getNicInfo(cmd *pm.Command) (interface{}, error) {
 		ret[i].HardwareAddr = ifc.HardwareAddr
 		ret[i].Flags = ifc.Flags
 		ret[i].Addrs = ifc.Addrs
-		dat, err := ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/speed")
-		if err != nil {
-			speed = 0
-		} else {
-			speed, _ = strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
-		}
+		// no need to check for erros here, as the file is necessarily there,
+		// as it's read in just before by net.Interfaces
+		dat, _ := ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/speed")
+		speed, _ = strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].Speed = speed
+		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/carrier")
+		carrier, _ := strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
+		ret[i].Carrier = carrier
+		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/operstate")
+		operstate, _:= strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
+		ret[i].OperState = operstate
 	}
 	return ret, nil
 }

--- a/base/builtin/info.go
+++ b/base/builtin/info.go
@@ -66,8 +66,8 @@ func getMemInfo(cmd *pm.Command) (interface{}, error) {
 type NicInfo struct {
 	net.InterfaceStat
 	Speed     int64 `json:"speed"`
-	Carrier   int64 `json:"carrier"`
-	OperState int64 `json:"operstate"`
+	Carrier   bool `json:"carrier"`
+	OperState bool `json:"operstate"`
 }
 
 func getNicInfo(cmd *pm.Command) (interface{}, error) {
@@ -89,10 +89,10 @@ func getNicInfo(cmd *pm.Command) (interface{}, error) {
 		speed, _ = strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].Speed = speed
 		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/carrier")
-		carrier, _ := strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
+		carrier, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].Carrier = carrier
 		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/operstate")
-		operstate, _ := strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
+		operstate, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].OperState = operstate
 	}
 	return ret, nil

--- a/base/builtin/info.go
+++ b/base/builtin/info.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shirou/gopsutil/net"
 	base "github.com/threefoldtech/0-core/base"
 	"github.com/threefoldtech/0-core/base/pm"
+	bufio "gopkg.in/bufio.v1"
 )
 
 const (
@@ -91,7 +92,7 @@ func getNicInfo(cmd *pm.Command) (interface{}, error) {
 		carrier, _ := strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].Carrier = carrier
 		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/operstate")
-		operstate, _:= strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
+		operstate, _ := strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].OperState = operstate
 	}
 	return ret, nil

--- a/base/builtin/info.go
+++ b/base/builtin/info.go
@@ -89,10 +89,10 @@ func getNicInfo(cmd *pm.Command) (interface{}, error) {
 		speed, _ = strconv.ParseInt(strings.Trim(string(dat), "\n"), 10, 64)
 		ret[i].Speed = speed
 		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/carrier")
-		carrier, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"), 10, 64)
+		carrier, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"))
 		ret[i].Carrier = carrier
 		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/operstate")
-		operstate, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"), 10, 64)
+		operstate, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"))
 		ret[i].OperState = operstate
 	}
 	return ret, nil

--- a/base/builtin/info.go
+++ b/base/builtin/info.go
@@ -66,8 +66,8 @@ func getMemInfo(cmd *pm.Command) (interface{}, error) {
 type NicInfo struct {
 	net.InterfaceStat
 	Speed     int64 `json:"speed"`
-	Carrier   bool `json:"carrier"`
-	OperState bool `json:"operstate"`
+	Carrier   bool  `json:"carrier"`
+	OperState bool  `json:"operstate"`
 }
 
 func getNicInfo(cmd *pm.Command) (interface{}, error) {
@@ -92,7 +92,14 @@ func getNicInfo(cmd *pm.Command) (interface{}, error) {
 		carrier, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"))
 		ret[i].Carrier = carrier
 		dat, _ = ioutil.ReadFile("/sys/class/net/" + ifc.Name + "/operstate")
-		operstate, _ := strconv.ParseBool(strings.Trim(string(dat), "\n"))
+		op := strings.Trim(string(dat), "\n")
+		var operstate bool
+		switch op {
+		case "up", "1":
+			operstate = true
+		case "down", "0":
+			operstate = false
+		}
 		ret[i].OperState = operstate
 	}
 	return ret, nil


### PR DESCRIPTION
 ## disk.isstandby 

When a disk is silenced with `disk.spindown(disk,timeval)`, we need to check in monitoring tools whether a disk is effectively in 'standby' state before accessing it. this call adds capability to do so. now we need to search for monitoring tools that do effective actions that start the disk back up and first verify it's state before writing. there is no need to restart a disk, if it's in standby state, unless you really want to use it. i.e. not during monitor calls

## info.nic

the semantics for verifying if a nic has carrier wasn't there. now returns bool for `carrier` and `operstate`

## kernel parameter `noautonic`

Apparently, the switches @ bancadati get 'confused' when nics get brought up and have activity prior to create a 'lacp' bond (some sort of bonding without lacp). These kernel parameter tells `core0` to not try to enable/dhcp this interface. 
use an `noautonic=$interface` for every nic that you don't want to be touched during boot.