### PR TITLE
Allow environment variables interpolation in startup.toml

### DIFF
--- a/base/mgr/pm.go
+++ b/base/mgr/pm.go
@@ -245,6 +245,20 @@ func processArgs(args map[string]interface{}, values map[string]interface{}) {
 	}
 }
 
+func osEnvironAsMap() map[string]interface{} {
+	r := make(map[string]interface{})
+	var k, v string
+	for _, l := range os.Environ() {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) == 2 {
+			k = parts[0]
+			v = parts[1]
+			r[k] = v
+		}
+	}
+	return r
+}
+
 /*
 RunSlice runs a slice of processes honoring dependencies. It won't just
 start in order, but will also make sure a service won't start until it's dependencies are
@@ -284,6 +298,7 @@ func RunSlice(slice settings.StartupSlice) {
 		}
 
 		processArgs(startup.Args, cmdline)
+		processArgs(startup.Args, osEnvironAsMap())
 
 		cmd := &pm.Command{
 			ID:              startup.Key(),

--- a/base/mgr/pm.go
+++ b/base/mgr/pm.go
@@ -248,13 +248,10 @@ func processArgs(args map[string]interface{}, values map[string]interface{}) {
 // convert os Environ slice to map mainly to be used in processArgs for startup files
 func osEnvironAsMap() map[string]interface{} {
 	r := make(map[string]interface{})
-	var k, v string
 	for _, l := range os.Environ() {
 		parts := strings.SplitN(l, "=", 2)
 		if len(parts) == 2 {
-			k = parts[0]
-			v = parts[1]
-			r[k] = v
+			r[parts[0]] = parts[1]
 		}
 	}
 	return r

--- a/base/mgr/pm.go
+++ b/base/mgr/pm.go
@@ -245,6 +245,7 @@ func processArgs(args map[string]interface{}, values map[string]interface{}) {
 	}
 }
 
+// convert os Environ slice to map mainly to be used in processArgs for startup files
 func osEnvironAsMap() map[string]interface{} {
 	r := make(map[string]interface{})
 	var k, v string
@@ -297,8 +298,8 @@ func RunSlice(slice settings.StartupSlice) {
 			startup.Args = make(map[string]interface{})
 		}
 
-		processArgs(startup.Args, cmdline)
 		processArgs(startup.Args, osEnvironAsMap())
+		processArgs(startup.Args, cmdline)
 
 		cmd := &pm.Command{
 			ID:              startup.Key(),


### PR DESCRIPTION
Allows customizing the autostart toml files based on environment variables

e.g 
```toml
[startup.redisserver]
name = "core.system"

[startup.redisserver.args]
name = "/usr/bin/redis-server"
# should use default values here?
args = ["--port", "{REDIS_PORT}"]

```

## Python client example
```ipython
In [4]: zcl.container.create(root_url="https://hub.grid.tf/thabet/redisautostart.fli
   ...: st", env={"REDIS_PORT":"9300"}).get()
Out[4]: 2
```

## 0-core info
```bash
ip netns exec 2 netstat -nlpt 
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:9300            0.0.0.0:*               LISTEN      648/redis-server *:
tcp        0      0 :::9300                 :::*                    LISTEN      648/redis-server *:
```