### PR TITLE
Fix disks.list() call crashing when no disks are found

### DIFF
--- a/apps/plugins/base/disk/disk.go
+++ b/apps/plugins/base/disk/disk.go
@@ -515,8 +515,16 @@ func (d *Manager) list(ctx pm.Context) (interface{}, error) {
 		return nil, err
 	}
 
+	// If lsblk didn't returned an error and stdout is empty,
+	// then no disks was found, but we won't be able to Unmarshal the response
+	// We returns an empty list directly
+	var response = []byte(result.Streams.Stdout())
+	if len(response) == 0 {
+		return []*DiskInfoResult{}, nil
+	}
+
 	var disks lsblkListResult
-	if err := json.Unmarshal([]byte(result.Streams.Stdout()), &disks); err != nil {
+	if err := json.Unmarshal(response, &disks); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
When no disks are found on the node, the call to `lsblk -J` returns an empty response, which makes 0-core to complains because it can't parse the json response. Let returns an empty list when this arrives.

## Before fix
```
In [X]: n.disks.list()
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
/opt/code/github/threefoldtech/jumpscale_core/cmds/js_shell in <module>()
----> 1 n.disks.list()

/opt/code/github/threefoldtech/jumpscale_lib/JumpscaleLib/sal_zos/disks/Disks.py in list(self)
     30         """
     31         disks = []
---> 32         for disk_info in self.client.disk.list():
     33             disks.append(Disk(
     34                 node=self.node,

/opt/code/github/threefoldtech/jumpscale_lib/JumpscaleLib/clients/zero_os_protocol/DiskManager.py in list(self)
     63 
     64         if result.state != 'SUCCESS':
---> 65             raise RuntimeError('failed to list disks: %s' % result.stderr)
     66 
     67         if result.level != 20:  # 20 is JSON output.

RuntimeError: failed to list disks: 
```

## After fix
```
In [X]: n.disks.list()
Out[X]: []
```

This was a live test.