### PR TITLE
Apparently doing a loop over string runes copy bytes

### DIFF
--- a/base/stream/input.go
+++ b/base/stream/input.go
@@ -19,7 +19,6 @@ const (
 
 var (
 	log           = logging.MustGetLogger("stream")
-	pmMsgPattern  = regexp.MustCompile("^(\\d+)(:{2,3})(.*)$")
 	headerPattern = regexp.MustCompile(`^(\d+)(:{2,3})`)
 
 	multiLineTerm = "\n:::\n"
@@ -57,11 +56,11 @@ func Consume(wg *sync.WaitGroup, source io.ReadCloser, level uint16, handler Mes
 			defer wg.Done()
 		}
 
+		defer source.Close()
+
 		if err := c.consume(); err != nil {
 			log.Errorf("failed to read stream: %s", err)
 		}
-
-		source.Close()
 	}()
 }
 
@@ -80,8 +79,8 @@ func (c *consumerImpl) getHeaderFromMatch(m [][]byte) *header {
 //newLineOrEOF will return index of the next \n or EOF (end of file or string)
 func (c *consumerImpl) newLineOrEOF(b []byte) int {
 	var i int
-	var x rune
-	for i, x = range string(b) {
+	var x byte
+	for i, x = range b {
 		if x == '\n' {
 			break
 		}


### PR DESCRIPTION
A potential fix for the memory leak

The actual fix is in this method
 https://github.com/threefoldtech/0-core/compare/development...threefoldtech:development-leak-fix?expand=1#diff-3513753f20c42764d30060fc4f9632e4R80 

Apparently when u do iteration over string runes it actually copies the entire string. This was only visible after doing memory profiling for a machine that runs lots of processes that produces lots of data. 

After this fix, the machine memory really went down, and even after a heavy load, the memory consumption went down with time.

We still need to test this in production to see if it actually fixes the issue.